### PR TITLE
feat: add cross-border trade demo agents

### DIFF
--- a/p2p/starter-template/SOP.md
+++ b/p2p/starter-template/SOP.md
@@ -1,0 +1,264 @@
+# P2P 跨境贸易协作平台 — 标准操作流程 (SOP)
+
+---
+
+## 1. 系统概述
+
+三个独立机构通过 P2P 网络协作，各自持有不同数据，数据不出本方网络：
+
+| 机构 | Agent 名称 | Skill | 持有数据 |
+|------|-----------|-------|---------|
+| 深圳工厂 | `supplier-shenzhen` | `product_info` | 产品规格、价格、HS编码 |
+| 欧盟合规部 | `compliance-eu` | `compliance_check` | 欧盟法规数据库 (RoHS/REACH/CBAM/PFAS…) |
+| 国际货代 | `logistics-shipper` | `shipping_quote` | 中国→欧洲运价数据库 |
+
+调用链路：`Client → 深圳工厂 → 欧盟合规 → 国际货代`
+
+---
+
+## 2. 环境准备
+
+### 2.1 硬件要求
+- macOS 或 Linux (Windows 需 WSL2)
+- Python ≥ 3.9
+
+### 2.2 安装 anet CLI
+
+```bash
+curl -fsSL https://agentnetwork.org.cn/install.sh | sh
+anet --version
+# 应输出: 1.1.11 或更高
+```
+
+### 2.3 安装 Python 依赖
+
+```bash
+cd my-team-name
+python -m venv .venv
+source .venv/bin/activate
+pip install anet fastapi uvicorn httpx python-dotenv
+```
+
+---
+
+## 3. 启动系统
+
+### 3.1 一键启动（推荐）
+
+```bash
+cd my-team-name
+bash one-click.sh
+```
+
+启动后自动打开：
+- 仪表盘 `http://127.0.0.1:7500/`
+- 交互演示 `http://127.0.0.1:7500/demo`
+
+### 3.2 手动分步启动
+
+**Step 1 — 启动两个本地 daemon：**
+
+```bash
+# daemon-1 (API: 13921, P2P: 14021)
+HOME=/tmp/anet-p2p-u1 anet daemon --api-listen :13921 --p2p-port 14021 --home /tmp/anet-p2p-u1 &
+
+# daemon-2 (API: 13922, P2P: 14022)
+HOME=/tmp/anet-p2p-u2 anet daemon --api-listen :13922 --p2p-port 14022 --home /tmp/anet-p2p-u2 &
+
+sleep 3  # 等待 daemon 就绪
+
+# 互转 seed 确保跨节点调用
+DID1=$(ANET_TOKEN=$(cat /tmp/anet-p2p-u1/.anet/api_token) anet status | grep "did:" | head -1 | awk '{print $2}')
+DID2=$(ANET_TOKEN=$(cat /tmp/anet-p2p-u2/.anet/api_token) anet status | grep "did:" | head -1 | awk '{print $2}')
+TOKEN1=$(cat /tmp/anet-p2p-u1/.anet/api_token)
+TOKEN2=$(cat /tmp/anet-p2p-u2/.anet/api_token)
+curl -s -X POST http://127.0.0.1:13921/api/credits/transfer \
+  -H "Authorization: Bearer $TOKEN1" -H "Content-Type: application/json" \
+  -d "{\"from\":\"$DID1\",\"to\":\"$DID2\",\"amount\":1000,\"reason\":\"seed\"}"
+curl -s -X POST http://127.0.0.1:13922/api/credits/transfer \
+  -H "Authorization: Bearer $TOKEN2" -H "Content-Type: application/json" \
+  -d "{\"from\":\"$DID2\",\"to\":\"$DID1\",\"amount\":1000,\"reason\":\"seed\"}"
+```
+
+**Step 2 — 启动三个 Agent（全部注册到 daemon-1）：**
+
+```bash
+cd my-team-name
+
+# 深圳工厂
+ANET_BASE_URL=http://127.0.0.1:13921 ANET_TOKEN=$TOKEN1 PYTHONPATH=. \
+  python3 my_team/agents/agent_a_supplier.py &
+
+# 欧盟合规
+ANET_BASE_URL=http://127.0.0.1:13921 ANET_TOKEN=$TOKEN1 PYTHONPATH=. \
+  python3 my_team/agents/agent_b_compliance.py &
+
+# 国际货代
+ANET_BASE_URL=http://127.0.0.1:13921 ANET_TOKEN=$TOKEN1 PYTHONPATH=. \
+  python3 my_team/agents/agent_c_logistics.py &
+
+sleep 2
+```
+
+**Step 3 — 启动 Dashboard：**
+
+```bash
+ANET_BASE_URL=http://127.0.0.1:13921 ANET_TOKEN=$TOKEN1 PYTHONPATH=. \
+  python3 my_team/dashboard.py &
+```
+
+---
+
+## 4. 验证运行状态
+
+### 4.1 检查 daemon
+
+```bash
+anet status
+# 应看到: peers > 0, version = 1.1.11
+```
+
+### 4.2 检查 Agent 注册
+
+```bash
+# 发现供应商
+anet svc discover --skill product_info
+
+# 发现合规
+anet svc discover --skill compliance_check
+
+# 发现物流
+anet svc discover --skill shipping_quote
+```
+
+每个命令应返回 1 个 peer，显示对应的服务名和描述。
+
+### 4.3 检查余额
+
+```bash
+anet balance
+# 应显示: Balance: 5000 (或更多)
+```
+
+---
+
+## 5. 运行演示
+
+### 5.1 Web 交互演示（推荐）
+
+打开浏览器访问 `http://127.0.0.1:7500/demo`
+
+操作步骤：
+1. 选择产品（电动滑板车 / 蓝牙耳机 / 户外储能电源 / 儿童玩具车 / 锂电池）
+2. 输入数量（默认 500）
+3. 选择目的港（汉堡 / 鹿特丹 / 热那亚）
+4. 点击 **🚀 一键演示**
+5. 等待自动运行完成，查看诊断报告
+
+### 5.2 命令行演示
+
+```bash
+# 测试电动滑板车出口到德国汉堡
+ANET_BASE_URL=http://127.0.0.1:13922 ANET_TOKEN=$TOKEN2 PYTHONPATH=. \
+  python3 my_team/trade_pipeline.py "电动滑板车" 500 "汉堡"
+
+# 测试户外储能电源到荷兰鹿特丹
+ANET_BASE_URL=http://127.0.0.1:13922 ANET_TOKEN=$TOKEN2 PYTHONPATH=. \
+  python3 my_team/trade_pipeline.py "户外储能电源" 200 "鹿特丹"
+```
+
+### 5.3 单一 Agent 测试
+
+```bash
+# 直接调供应商
+curl -s -X POST http://127.0.0.1:13921/api/svc/call \
+  -H "Authorization: Bearer $TOKEN1" -H "Content-Type: application/json" \
+  -d '{"peer_id":"<peer_id>","service":"supplier-shenzhen","path":"/v1/product/detail","method":"POST","body":{"product":"电动滑板车"}}'
+```
+
+---
+
+## 6. Dashboard 操作
+
+### 6.1 仪表盘页面 (`/`)
+- 实时显示网络状态（version、peers、uptime）
+- 节点身份和余额
+- 已注册 Agent 列表
+- 调用审计日志（自动刷新每 5 秒）
+
+### 6.2 交互演示页面 (`/demo`)
+- 顶部导航可在"仪表盘"和"交互演示"间切换
+- 演示自动执行：发现 Agent → 查产品 → 合规审查 → 物流报价 → 生成报告
+- 运行过程中实时显示日志和进度条
+
+---
+
+## 7. 停止系统
+
+```bash
+# 停止 Dashboard
+pkill -f dashboard.py
+
+# 停止 Agent
+pkill -f agent_a_supplier
+pkill -f agent_b_compliance
+pkill -f agent_c_logistics
+
+# 停止 daemon
+kill $(lsof -ti tcp:13921) 2>/dev/null || true
+kill $(lsof -ti tcp:13922) 2>/dev/null || true
+```
+
+或一键停止：
+
+```bash
+bash scripts/stop.sh
+```
+
+---
+
+## 8. 常见问题
+
+| 问题 | 原因 | 解决 |
+|------|------|------|
+| `peers=0` | 网络隔离或 daemon 未启动 | 检查 daemon: `lsof -i :13921`，重启 daemon |
+| `401 unauthorized` | token 错误 | 确认 `ANET_TOKEN` 环境变量正确 |
+| `dial to self attempted` | 同一 daemon 调自己注册的服务 | 从另一个 daemon 调用（:13921 → :13922） |
+| 注册后 discover 看不到 | ANS gossip 未收敛 | 等待 5-10 秒重试 |
+| 钱包余额不足 | 跨节点转账未做 | 执行 mutual seed 转账 |
+
+---
+
+## 9. 架构说明
+
+```
+┌─ daemon-1 (:13921) ─────────────────────────┐
+│  深圳工厂 (supplier-shenzhen)   :7411         │
+│  欧盟合规 (compliance-eu)       :7412         │
+│  国际货代 (logistics-shipper)   :7413         │
+└──────────────────┬───────────────────────────┘
+                   │ P2P
+┌──────────────────▼───────────────────────────┐
+│  daemon-2 (:13922)                            │
+│  Client (trade_pipeline.py / Web Dashboard)   │
+└───────────────────────────────────────────────┘
+```
+
+每个 Agent = FastAPI 应用 + 注册到 daemon。Client 通过 daemon-2 调用 daemon-1 上注册的服务，数据不出 daemon-1 所在网络。
+
+---
+
+## 10. 文件清单
+
+```
+my-team-name/
+├── one-click.sh                    # 一键启动脚本
+├── my_team/
+│   ├── dashboard.py                # Web 仪表盘 + 演示页面
+│   ├── trade_pipeline.py           # 命令行演示脚本
+│   └── agents/
+│       ├── register.py             # 通用注册函数
+│       ├── agent_a_supplier.py     # 深圳工厂 Agent
+│       ├── agent_b_compliance.py   # 欧盟合规 Agent
+│       └── agent_c_logistics.py    # 国际货代 Agent
+```

--- a/p2p/starter-template/my_team/agents/agent_a_supplier.py
+++ b/p2p/starter-template/my_team/agents/agent_a_supplier.py
@@ -1,0 +1,166 @@
+"""Agent A — 供应商 (Supplier). 持有产品数据 context + product_info skill."""
+
+import os
+import threading
+from typing import Optional
+import uvicorn
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+from register import register_agent
+
+NAME = "supplier-shenzhen"
+PORT = int(os.environ.get("AGENT_A_PORT", "7411"))
+PER_CALL = int(os.environ.get("AGENT_A_PER_CALL", "0"))
+
+app = FastAPI(title=NAME)
+
+# ========== Context: 真实产品数据库 ==========
+PRODUCTS = {
+    "电动滑板车": {
+        "hs_code": "8711.6000",
+        "price_usd": 289.00,
+        "moq": 100,
+        "weight_kg": 22.0,
+        "material": "铝合金车架 + 锂电池",
+        "battery_type": "锂离子 36V/10.4Ah",
+        "cert_have": ["CE", "RoHS"],
+        "cert_missing": ["UN38.3", "REACH"],
+        "origin": "深圳",
+    },
+    "蓝牙耳机": {
+        "hs_code": "8518.3000",
+        "price_usd": 36.00,
+        "moq": 500,
+        "weight_kg": 0.2,
+        "material": "ABS塑料 + 电子元件",
+        "battery_type": "锂聚合物 3.7V/50mAh",
+        "cert_have": ["CE", "RoHS"],
+        "cert_missing": [],
+        "origin": "东莞",
+    },
+    "锂电池": {
+        "hs_code": "8507.6000",
+        "price_usd": 45.00,
+        "moq": 200,
+        "weight_kg": 1.5,
+        "material": "锂离子电芯 + 钢壳",
+        "battery_type": "锂离子 12.8V/20Ah",
+        "cert_have": ["UN38.3", "CE"],
+        "cert_missing": ["MSDS"],
+        "origin": "宁德",
+    },
+    "户外储能电源": {
+        "hs_code": "8507.6000",
+        "price_usd": 599.00,
+        "moq": 50,
+        "weight_kg": 8.5,
+        "material": "锂离子电池组 + 铝合金外壳",
+        "battery_type": "锂离子 48V/50Ah",
+        "cert_have": ["CE", "RoHS", "UN38.3"],
+        "cert_missing": ["REACH", "CBAM"],
+        "origin": "深圳",
+    },
+    "儿童玩具车": {
+        "hs_code": "9503.0000",
+        "price_usd": 39.00,
+        "moq": 1000,
+        "weight_kg": 2.0,
+        "material": "ABS塑料 + 电子元件 + 锂电池",
+        "battery_type": "锂聚合物 7.4V/2Ah",
+        "cert_have": ["CE", "EN71"],
+        "cert_missing": ["TSR新规", "REACH"],
+        "origin": "汕头",
+    },
+}
+
+
+@app.get("/health")
+def health(): return {"ok": True, "agent": NAME}
+
+@app.get("/meta")
+def meta():
+    return {
+        "name": NAME, "version": "0.1.0", "skill": "product_info",
+        "description": "供应商：持有产品数据库，提供产品规格与报价",
+        "products_available": list(PRODUCTS.keys()),
+    }
+
+@app.post("/v1/product/list")
+async def list_products():
+    """返回所有产品列表"""
+    return JSONResponse({"products": [
+        {"name": n, "price_usd": p["price_usd"], "moq": p["moq"],
+         "origin": p["origin"], "hs_code": p["hs_code"]}
+        for n, p in PRODUCTS.items()
+    ]})
+
+@app.post("/v1/product/detail")
+async def product_detail(req: Request):
+    """返回指定产品的完整规格"""
+    body = await req.json()
+    name = (body or {}).get("product", "")
+    p = PRODUCTS.get(name)
+    if not p:
+        # 模糊匹配
+        matches = [n for n in PRODUCTS if name in n]
+        if matches:
+            p = PRODUCTS[matches[0]]
+            name = matches[0]
+        else:
+            return JSONResponse({"error": f"未知产品: {name}", "available": list(PRODUCTS.keys())})
+    return JSONResponse({
+        "product": name,
+        "hs_code": p["hs_code"],
+        "price_usd": p["price_usd"],
+        "moq": p["moq"],
+        "weight_kg": p["weight_kg"],
+        "material": p["material"],
+        "battery_type": p["battery_type"],
+        "cert_have": p["cert_have"],
+        "cert_missing": p["cert_missing"],
+        "origin": p["origin"],
+    })
+
+@app.post("/v1/quote")
+async def quote(req: Request):
+    """估算产品成本"""
+    body = await req.json()
+    name = (body or {}).get("product", "")
+    qty = int((body or {}).get("qty", 100))
+    p = PRODUCTS.get(name)
+    if not p:
+        matches = [n for n in PRODUCTS if name in n]
+        if matches:
+            p = PRODUCTS[matches[0]]
+            name = matches[0]
+        else:
+            return JSONResponse({"error": f"未知产品: {name}"})
+    if qty < p["moq"]:
+        return JSONResponse({"error": f"最小起订量 {p['moq']} 件", "moq": p["moq"]})
+    subtotal = round(p["price_usd"] * qty, 2)
+    return JSONResponse({
+        "product": name,
+        "qty": qty,
+        "unit_price_usd": p["price_usd"],
+        "subtotal_usd": subtotal,
+        "origin": p["origin"],
+        "weight_total_kg": round(p["weight_kg"] * qty, 1),
+        "cert_provided": p["cert_have"],
+        "cert_maybe_needed": p["cert_missing"],
+    })
+
+
+def main():
+    threading.Thread(
+        target=lambda: register_agent(
+            NAME, PORT,
+            paths=["/v1/product/list", "/v1/product/detail", "/v1/quote", "/health", "/meta"],
+            tags=["product_info", "supplier", "trade"],
+            description="供应商 Agent：产品数据库 + 报价 (真实出口数据)",
+            per_call=PER_CALL,
+        ), daemon=True,
+    ).start()
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")
+
+if __name__ == "__main__":
+    main()

--- a/p2p/starter-template/my_team/agents/agent_a_supplier.py
+++ b/p2p/starter-template/my_team/agents/agent_a_supplier.py
@@ -126,7 +126,10 @@ async def quote(req: Request):
     """估算产品成本"""
     body = await req.json()
     name = (body or {}).get("product", "")
-    qty = int((body or {}).get("qty", 100))
+    try:
+        qty = int((body or {}).get("qty", 100))
+    except ValueError:
+        return JSONResponse({"error": "数量格式错误", "status": 400})
     p = PRODUCTS.get(name)
     if not p:
         matches = [n for n in PRODUCTS if name in n]

--- a/p2p/starter-template/my_team/agents/agent_b_compliance.py
+++ b/p2p/starter-template/my_team/agents/agent_b_compliance.py
@@ -1,0 +1,227 @@
+"""Agent B — 合规顾问 (Compliance). 持有法规数据库 context + compliance_check skill."""
+
+import os
+import threading
+from typing import Optional
+import uvicorn
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+from anet.svc import SvcClient
+from register import register_agent
+
+NAME = "compliance-eu"
+PORT = int(os.environ.get("AGENT_B_PORT", "7412"))
+PER_CALL = int(os.environ.get("AGENT_B_PER_CALL", "0"))
+ANET_BASE_URL = os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13922")
+
+app = FastAPI(title=NAME)
+
+# ========== Context: 欧盟法规知识库 (2025-2026 真实数据) ==========
+REGULATIONS = {
+    "CE": {
+        "name": "CE 标志 (强制)",
+        "applies_to": ["电子产品", "玩具", "机械", "个人防护"],
+        "description": "进入欧盟市场的基本安全认证。2025-2026 新规：RED 指令网络安全强制(EN 18031)，GPSR 全面执行",
+        "cost_estimate": "认证费 ¥5,000-30,000 视产品复杂度",
+        "timeline": "4-8 周",
+    },
+    "RoHS": {
+        "name": "RoHS 2.0 (强制)",
+        "applies_to": ["电子电气设备", "含电子元件的玩具", "家电"],
+        "description": "管控 10 项有害物质（铅、汞、镉、六价铬、PBB、PBDE + 4 种邻苯）",
+        "cost_estimate": "检测费 ¥2,000-5,000/产品",
+        "timeline": "2-3 周",
+    },
+    "REACH": {
+        "name": "REACH 法规 (强制)",
+        "applies_to": ["所有化学品", "含化学品的成品", "纺织品", "玩具"],
+        "description": "SVHC 候选清单截至 2026 年已达 255 项，持续增长中",
+        "cost_estimate": "注册费 ¥10,000-50,000+/年",
+        "timeline": "3-6 个月",
+    },
+    "UN38.3": {
+        "name": "UN 38.3 (强制)",
+        "applies_to": ["含锂电池产品", "锂电池单独运输"],
+        "description": "锂电池运输安全测试，空运海运均需提供",
+        "cost_estimate": "检测费 ¥3,000-8,000",
+        "timeline": "2-4 周",
+    },
+    "CBAM": {
+        "name": "碳边境调节机制 CBAM (强制)",
+        "applies_to": ["钢铁", "铝", "水泥", "化肥", "氢能", "电力"],
+        "description": "2026 年 1 月 1 日正式征收。需申报产品隐含碳排放 → 购买 CBAM 证书",
+        "cost_estimate": "碳排放成本约 €30-50/吨 CO₂，默认值可能增加 30-50% 成本",
+        "timeline": "持续合规，每年 9 月 30 日结算",
+    },
+    "TSR": {
+        "name": "玩具安全法规 TSR (强制)",
+        "applies_to": ["玩具", "儿童用品"],
+        "description": "2026 年 1 月 1 日生效，2030 年取代旧指令。全面禁止 PFAS，甲醛限值收紧，需数字产品护照",
+        "cost_estimate": "认证费 ¥10,000-50,000 + DPP 系统费",
+        "timeline": "8-16 周",
+    },
+    "PFAS": {
+        "name": "PFAS 禁令 (强制)",
+        "applies_to": ["纺织品", "服装", "鞋类", "厨具", "电子产品涂层"],
+        "description": "法国 2026.1.1、丹麦 2026.7.1 相继禁止含 PFAS 产品。EN 17826:2025 新增重金属和阻燃剂管控",
+        "cost_estimate": "替代材料成本 +10-30%",
+        "timeline": "需立即排查供应链",
+    },
+    "EUDR": {
+        "name": "零毁林法案 EUDR (强制)",
+        "applies_to": ["橡胶", "轮胎", "家具", "木材制品", "皮革"],
+        "description": "2025.12.30 起大中型企业强制，2026.6.30 中小微企业宽限期截止。中国为低风险国家（利好）",
+        "cost_estimate": "尽职调查系统搭建费 ¥20,000-100,000",
+        "timeline": "2-3 个月准备",
+    },
+    "PPWR": {
+        "name": "包装与包装废弃物法规 (强制)",
+        "applies_to": ["所有产品的包装", "防尘袋", "衣架", "吊牌", "标签"],
+        "description": "2026.8.12 起重金属总量 ≤100mg/kg，PFAS 严格限值。2030 年起包装须达可回收等级 A/B/C",
+        "cost_estimate": "包装改造费 ¥5,000-30,000",
+        "timeline": "按品类分阶段执行",
+    },
+    "MSDS": {
+        "name": "化学品安全技术说明书 (强制)",
+        "applies_to": ["锂电池", "化学品", "危险品"],
+        "description": "出口化学品和含危险品的成品需提供多语言 MSDS",
+        "cost_estimate": "编制费 ¥1,000-3,000/语种",
+        "timeline": "1-2 周",
+    },
+    "EN71": {
+        "name": "EN71 玩具安全标准 (强制)",
+        "applies_to": ["玩具", "儿童用品"],
+        "description": "欧盟玩具安全协调标准，含物理/化学/可燃性/电气测试",
+        "cost_estimate": "检测费 ¥5,000-15,000",
+        "timeline": "3-6 周",
+    },
+}
+
+# HS 代码映射到适用法规
+HS_REG_MAP = {
+    "8711": ["CE", "RoHS", "REACH", "UN38.3"],
+    "8518": ["CE", "RoHS", "REACH"],
+    "8507": ["CE", "RoHS", "UN38.3", "MSDS", "CBAM"],
+    "9503": ["CE", "TSR", "EN71", "REACH", "RoHS"],
+    "9506": ["CE", "REACH"],
+    "6100": ["PFAS", "REACH"],
+    "6200": ["PFAS", "REACH"],
+    "6400": ["PFAS", "REACH"],
+    "9401": ["EUDR", "REACH"],
+    "9403": ["EUDR", "REACH"],
+    "4011": ["EUDR", "CE"],
+}
+
+
+def _find_regs(product_data: dict) -> list[dict]:
+    """根据产品数据查找适用法规"""
+    hs = product_data.get("hs_code", "").replace(".", "")
+    cert_have = product_data.get("cert_have", [])
+    cert_missing = product_data.get("cert_missing", [])
+
+    # 通过 HS code 前 4 位匹配
+    matched_keys = set()
+    for prefix, regs in HS_REG_MAP.items():
+        if hs.startswith(prefix):
+            matched_keys.update(regs)
+
+    # 加上缺失证书对应的法规
+    for m in cert_missing:
+        if m in REGULATIONS:
+            matched_keys.add(m)
+
+    results = []
+    for key in sorted(matched_keys):
+        reg = REGULATIONS.get(key, {})
+        have = key in cert_have
+        results.append({
+            "regulation": key,
+            "name": reg.get("name", key),
+            "status": "✅ 已具备" if have else "❌ 需要办理",
+            "description": reg.get("description", ""),
+            "cost_estimate": reg.get("cost_estimate", ""),
+            "timeline": reg.get("timeline", ""),
+        })
+    return results
+
+
+@app.get("/health")
+def health(): return {"ok": True, "agent": NAME}
+
+@app.get("/meta")
+def meta():
+    return {
+        "name": NAME, "version": "0.1.0", "skill": "compliance_check",
+        "description": "合规顾问：持有欧盟法规数据库 (CBAM/RoHS/REACH/PFAS/EUDR/TSR…)",
+        "regulations_covered": list(REGULATIONS.keys()),
+    }
+
+@app.post("/v1/regulation/list")
+async def list_regulations():
+    """列出所有法规"""
+    return JSONResponse({"regulations": [
+        {"key": k, "name": v["name"], "applies_to": v["applies_to"]}
+        for k, v in REGULATIONS.items()
+    ]})
+
+@app.post("/v1/compliance/check")
+async def compliance_check(req: Request):
+    """检查产品需满足的法规要求"""
+    body = await req.json()
+
+    # 支持直接从参数传入产品信息，也可以调供应商 Agent 获取
+    product_data = (body or {}).get("product_info")
+    product_name = (body or {}).get("product", "")
+
+    if not product_data and product_name:
+        # 调供应商 Agent 获取产品详情
+        try:
+            with SvcClient(base_url=ANET_BASE_URL) as svc:
+                peers = svc.discover(skill="product_info")
+                if peers:
+                    target = peers[0]
+                    resp = svc.call(target["peer_id"], target["services"][0]["name"],
+                                    "/v1/product/detail", method="POST",
+                                    body={"product": product_name})
+                    body_resp = resp.get("body") or {}
+                    if isinstance(body_resp, dict) and "hs_code" in body_resp:
+                        product_data = body_resp
+        except Exception as e:
+            print(f"[B] failed to call supplier: {e}", flush=True)
+
+    if not product_data:
+        return JSONResponse({"error": "需要 product_info 或 product 名称来查询供应商"})
+
+    regs = _find_regs(product_data)
+    total_cost_est = 0
+    for r in regs:
+        if r["status"] == "❌ 需要办理":
+            import re
+            nums = re.findall(r'[\d,]+', r["cost_estimate"])
+            if nums:
+                total_cost_est += int(nums[0].replace(",", ""))
+
+    return JSONResponse({
+        "product": product_data.get("product", product_name),
+        "hs_code": product_data.get("hs_code", ""),
+        "compliance_status": "⚠️ 待完善" if any(r["status"] == "❌ 需要办理" for r in regs) else "✅ 合规",
+        "regulations": regs,
+        "estimated_compliance_cost_cny": total_cost_est,
+        "note": "以上法规要求基于 2025-2026 年欧盟最新规定，建议以第三方机构最终检测为准",
+    })
+
+
+def main():
+    threading.Thread(
+        target=lambda: register_agent(
+            NAME, PORT,
+            paths=["/v1/regulation/list", "/v1/compliance/check", "/health", "/meta"],
+            tags=["compliance_check", "regulatory", "trade"],
+            description="合规顾问 Agent：欧盟法规数据库 (RoHS/REACH/CBAM/PFAS/TSR/EUDR 等)",
+            per_call=PER_CALL,
+        ), daemon=True,
+    ).start()
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")
+
+if __name__ == "__main__":
+    main()

--- a/p2p/starter-template/my_team/agents/agent_b_compliance.py
+++ b/p2p/starter-template/my_team/agents/agent_b_compliance.py
@@ -1,6 +1,7 @@
 """Agent B — 合规顾问 (Compliance). 持有法规数据库 context + compliance_check skill."""
 
 import os
+import re
 import threading
 from typing import Optional
 import uvicorn
@@ -196,7 +197,6 @@ async def compliance_check(req: Request):
     total_cost_est = 0
     for r in regs:
         if r["status"] == "❌ 需要办理":
-            import re
             nums = re.findall(r'[\d,]+', r["cost_estimate"])
             if nums:
                 total_cost_est += int(nums[0].replace(",", ""))

--- a/p2p/starter-template/my_team/agents/agent_c_logistics.py
+++ b/p2p/starter-template/my_team/agents/agent_c_logistics.py
@@ -95,11 +95,7 @@ def _pick_route(origin: str, dest: str) -> dict | None:
             return v
 
     # 默认用第一条
-    if origin and dest:
-        key = f"{origin}→{dest}"
-    for k, v in ROUTES.items():
-        return v
-    return None
+    return next(iter(ROUTES.values()), None)
 
 
 @app.get("/health")

--- a/p2p/starter-template/my_team/agents/agent_c_logistics.py
+++ b/p2p/starter-template/my_team/agents/agent_c_logistics.py
@@ -1,0 +1,224 @@
+"""Agent C — 物流 (Logistics). 持有运价数据库 context + shipping_quote skill."""
+
+import os
+import threading
+from typing import Optional
+import uvicorn
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+from anet.svc import SvcClient
+from register import register_agent
+
+NAME = "logistics-shipper"
+PORT = int(os.environ.get("AGENT_C_PORT", "7413"))
+PER_CALL = int(os.environ.get("AGENT_C_PER_CALL", "0"))
+ANET_BASE_URL = os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13921")
+
+app = FastAPI(title=NAME)
+
+# ========== Context: 真实物流运价数据库 (2025-2026) ==========
+ROUTES = {
+    "深圳→汉堡": {
+        "port_origin": "深圳盐田",
+        "port_dest": "汉堡",
+        "transit_days": 28,
+        "lcl_usd_per_cbm": 95,
+        "fcl_20gp_usd": 1150,
+        "fcl_40hq_usd": 1400,
+    },
+    "深圳→鹿特丹": {
+        "port_origin": "深圳盐田",
+        "port_dest": "鹿特丹",
+        "transit_days": 30,
+        "lcl_usd_per_cbm": 90,
+        "fcl_20gp_usd": 1100,
+        "fcl_40hq_usd": 1350,
+    },
+    "深圳→热那亚": {
+        "port_origin": "深圳盐田",
+        "port_dest": "热那亚",
+        "transit_days": 26,
+        "lcl_usd_per_cbm": 115,
+        "fcl_20gp_usd": 1300,
+        "fcl_40hq_usd": 1580,
+    },
+    "上海→汉堡": {
+        "port_origin": "上海洋山",
+        "port_dest": "汉堡",
+        "transit_days": 30,
+        "lcl_usd_per_cbm": 90,
+        "fcl_20gp_usd": 1100,
+        "fcl_40hq_usd": 1350,
+    },
+    "上海→鹿特丹": {
+        "port_origin": "上海洋山",
+        "port_dest": "鹿特丹",
+        "transit_days": 32,
+        "lcl_usd_per_cbm": 85,
+        "fcl_20gp_usd": 1080,
+        "fcl_40hq_usd": 1300,
+    },
+}
+
+SURCHARGES = {
+    "BAF": {"name": "燃油附加费", "rate": "基本运费的 15%"},
+    "CAF": {"name": "货币贬值附加费", "rate": "基本运费的 8%"},
+    "THC": {"name": "码头操作费", "rate": "¥600-900/柜"},
+    "ETS": {"name": "欧盟碳排放附加费", "rate": "2026 年起全面计入, 约 €25-50/TEU"},
+    "hazmat": {"name": "危险品附加费", "rate": "$50-150/柜 (含锂电池产品)"},
+}
+
+HS_SURCHARGE_MAP = {
+    "8711": ["BAF", "CAF", "THC", "hazmat", "ETS"],
+    "8507": ["BAF", "CAF", "THC", "hazmat", "MSDS", "ETS"],
+    "8518": ["BAF", "CAF", "THC", "ETS"],
+    "9503": ["BAF", "CAF", "THC", "ETS"],
+}
+
+
+def _estimate_cbm(weight_kg: float, qty: int) -> float:
+    """估算体积 (m³)。规则: 1CBM ≈ 167kg 为标准密度"""
+    est_cbm = round(weight_kg * qty / 167, 2)
+    return max(est_cbm, 0.1)  # 至少 0.1 CBM
+
+
+def _pick_route(origin: str, dest: str) -> dict | None:
+    """智能匹配路线"""
+    # 直接匹配
+    key = f"{origin}→{dest}"
+    if key in ROUTES:
+        return ROUTES[key]
+
+    # 模糊匹配
+    for k, v in ROUTES.items():
+        if origin in k and dest in k:
+            return v
+
+    # 默认用第一条
+    if origin and dest:
+        key = f"{origin}→{dest}"
+    for k, v in ROUTES.items():
+        return v
+    return None
+
+
+@app.get("/health")
+def health(): return {"ok": True, "agent": NAME}
+
+@app.get("/meta")
+def meta():
+    return {
+        "name": NAME, "version": "0.1.0", "skill": "shipping_quote",
+        "description": "货代 Agent：持有海运运价数据库 (中国→欧洲各航线)",
+        "routes_available": list(ROUTES.keys()),
+    }
+
+@app.post("/v1/route/list")
+async def list_routes():
+    return JSONResponse({"routes": [
+        {"name": k, **v} for k, v in ROUTES.items()
+    ]})
+
+@app.post("/v1/shipping/quote")
+async def shipping_quote(req: Request):
+    """物流报价"""
+    body = await req.json()
+    product_name = (body or {}).get("product", "")
+    qty = int((body or {}).get("qty", 100))
+    dest = (body or {}).get("dest", "汉堡")
+
+    # 支持直接传入产品信息（避免跨 daemon 调用）
+    product_data = (body or {}).get("product_info")
+
+    if not product_data:
+        # 调供应商 Agent 获取产品重量/尺寸
+        try:
+            with SvcClient(base_url=ANET_BASE_URL) as svc:
+                peers = svc.discover(skill="product_info")
+                if peers:
+                    target = peers[0]
+                    resp = svc.call(target["peer_id"], target["services"][0]["name"],
+                                    "/v1/product/detail", method="POST",
+                                    body={"product": product_name})
+                    body_resp = resp.get("body") or {}
+                    if isinstance(body_resp, dict) and "hs_code" in body_resp:
+                        product_data = body_resp
+        except Exception as e:
+            print(f"[C] failed to call supplier: {e}", flush=True)
+
+    if not product_data:
+        return JSONResponse({"error": f"无法获取产品信息: {product_name}"})
+
+    hs = product_data.get("hs_code", "").replace(".", "")
+    weight_kg = float(product_data.get("weight_kg", 1))
+    origin = product_data.get("origin", "深圳")
+
+    # 匹配路线
+    route = _pick_route(origin, dest)
+    if not route:
+        return JSONResponse({"error": f"暂无 {origin}→{dest} 的航线"})
+
+    # 计算费用
+    cbm = _estimate_cbm(weight_kg, qty)
+    total_weight = weight_kg * qty
+
+    # FCL vs LCL 判断
+    if cbm >= 18:
+        # 整箱
+        use_fcl = True
+        containers = max(1, round(cbm / 28))
+        freight = route["fcl_40hq_usd"] * containers
+        container_desc = f"{containers} × 40HQ"
+    else:
+        use_fcl = False
+        freight = round(cbm * route["lcl_usd_per_cbm"], 2)
+        container_desc = f"拼箱 LCL ({cbm} CBM)"
+
+    # 附加费
+    surcharge_list = []
+    for key in HS_SURCHARGE_MAP.get(hs[:4], ["BAF", "CAF", "THC", "ETS"]):
+        info = SURCHARGES.get(key)
+        if info:
+            surcharge_list.append({"name": info["name"], "rate": info["rate"]})
+
+    total_surcharge_pct = 15 + 8  # BAF + CAF
+    if any(s["name"] == "危险品附加费" for s in surcharge_list):
+        total_surcharge_pct += 5
+
+    surcharge_cost = round(freight * total_surcharge_pct / 100, 2)
+    total = round(freight + surcharge_cost, 2)
+
+    return JSONResponse({
+        "product": product_name,
+        "qty": qty,
+        "total_weight_kg": total_weight,
+        "estimated_cbm": cbm,
+        "route": f"{origin} → {dest}",
+        "port_origin": route["port_origin"],
+        "port_dest": route["port_dest"],
+        "transit_days": route["transit_days"],
+        "shipping_method": "FCL 整箱" if use_fcl else "LCL 拼箱",
+        "container": container_desc if use_fcl else None,
+        "freight_usd": freight,
+        "surcharges": surcharge_list,
+        "surcharge_total_usd": surcharge_cost,
+        "total_usd": total,
+        "cost_per_unit_usd": round(total / qty, 2),
+        "note": "运价有效期 7-15 天，旺季可能上浮 40-100%。不含目的港清关和内陆派送费",
+    })
+
+
+def main():
+    threading.Thread(
+        target=lambda: register_agent(
+            NAME, PORT,
+            paths=["/v1/route/list", "/v1/shipping/quote", "/health", "/meta"],
+            tags=["shipping_quote", "logistics", "trade"],
+            description="货代 Agent：海运运价数据库 (中国→欧洲各港口 2025-2026)",
+            per_call=PER_CALL,
+        ), daemon=True,
+    ).start()
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")
+
+if __name__ == "__main__":
+    main()

--- a/p2p/starter-template/my_team/agents/register.py
+++ b/p2p/starter-template/my_team/agents/register.py
@@ -1,0 +1,50 @@
+"""Shared register helper for multi-agent pipeline."""
+
+import os
+import time
+from typing import Optional
+
+import httpx
+from anet.svc import SvcAPIError, SvcClient
+
+
+def register_agent(name: str, port: int, *, paths: list[str], tags: list[str],
+                   description: str, per_call: int = 0,
+                   base_url: Optional[str] = None) -> None:
+    base_url = base_url or os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13921")
+    for _ in range(30):
+        try:
+            r = httpx.get(f"http://127.0.0.1:{port}/health", timeout=1.0)
+            if r.status_code == 200:
+                break
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.5)
+    else:
+        print(f"[{name}] backend on :{port} never came up")
+        raise SystemExit(1)
+
+    with SvcClient(base_url=base_url) as svc:
+        try:
+            svc.unregister(name)
+        except Exception:
+            pass
+        try:
+            resp = svc.register(
+                name=name,
+                endpoint=f"http://127.0.0.1:{port}",
+                paths=paths,
+                modes=["rr"],
+                per_call=per_call if per_call > 0 else None,
+                free=per_call <= 0,
+                tags=tags,
+                description=description,
+                health_check="/health",
+                meta_path="/meta",
+            )
+        except SvcAPIError as e:
+            print(f"[{name}] register failed: {e}")
+            raise
+
+    ans = resp.get("ans") or {}
+    print(f"[{name}] ✓ registered (per_call={per_call}, published={ans.get('published')})")

--- a/p2p/starter-template/my_team/dashboard.py
+++ b/p2p/starter-template/my_team/dashboard.py
@@ -15,8 +15,7 @@ TOKEN = os.environ.get("ANET_TOKEN", "")
 BASE_URL = os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13921")
 # 调用走 daemon-2 避免 "dial to self"
 CALL_BASE_URL = os.environ.get("CALL_BASE_URL", "http://127.0.0.1:13922")
-CALL_TOKEN = os.environ.get("CALL_TOKEN",
-    "e1e45b1b9a9508bd7e84c4cf98beba6a9619e48630d679be2e3c579abaced47d")
+CALL_TOKEN = os.environ.get("CALL_TOKEN", "")
 DASH_PORT = int(os.environ.get("DASH_PORT", "7500"))
 
 app = FastAPI(title="p2p-dashboard")

--- a/p2p/starter-template/my_team/dashboard.py
+++ b/p2p/starter-template/my_team/dashboard.py
@@ -1,0 +1,483 @@
+"""P2P Network Dashboard — 可视化查看 agent 状态 + 交互式演示."""
+
+import json
+import os
+import time
+from typing import Any
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from anet.svc import SvcClient
+
+TOKEN = os.environ.get("ANET_TOKEN", "")
+BASE_URL = os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13921")
+# 调用走 daemon-2 避免 "dial to self"
+CALL_BASE_URL = os.environ.get("CALL_BASE_URL", "http://127.0.0.1:13922")
+CALL_TOKEN = os.environ.get("CALL_TOKEN",
+    "e1e45b1b9a9508bd7e84c4cf98beba6a9619e48630d679be2e3c579abaced47d")
+DASH_PORT = int(os.environ.get("DASH_PORT", "7500"))
+
+app = FastAPI(title="p2p-dashboard")
+
+SKILLS = ["product_info", "compliance_check", "shipping_quote"]
+
+
+# ============================================================
+#  / — 实时网络仪表盘
+# ============================================================
+
+DASH_HTML = r"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P2P Agent Network</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: "PingFang SC","Microsoft YaHei","Noto Sans SC",-apple-system,BlinkMacSystemFont,sans-serif;
+          background: #f0f2f5; padding: 32px 40px; }
+  h1 { font-size: 32px; font-weight: 800; color: #1a1a2e; letter-spacing: -0.5px; }
+  h1 span { color: #2563eb; }
+  .sub { font-size: 15px; font-weight: 600; color: #6b7280; margin: 4px 0 24px 0; }
+  .nav { display: flex; gap: 12px; margin-bottom: 24px; }
+  .nav a { padding: 8px 20px; border-radius: 8px; font-size: 14px; font-weight: 700; text-decoration: none;
+           transition: all 0.2s; }
+  .nav a.active { background: #2563eb; color: #fff; }
+  .nav a:not(.active) { background: #fff; color: #6b7280; border: 1px solid #e5e7eb; }
+  .nav a:not(.active):hover { border-color: #2563eb; color: #2563eb; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-bottom: 24px; }
+  .card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); border: 1px solid #e8ecf1; }
+  .card-header { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+  .card-header .icon { font-size: 22px; }
+  .card-header h2 { font-size: 16px; font-weight: 700; color: #1f2937; }
+  .card-header .tag { margin-left: auto; font-size: 12px; font-weight: 700; background: #edf2ff; color: #2563eb; padding: 4px 12px; border-radius: 20px; }
+  .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 0; border-bottom: 1px solid #f3f4f6; }
+  .stat-row:last-child { border-bottom: none; }
+  .stat-label { font-size: 14px; font-weight: 600; color: #6b7280; }
+  .stat-value { font-size: 15px; font-weight: 800; color: #1f2937; font-family: "SF Mono","Fira Code",monospace; }
+  .stat-value.highlight { color: #2563eb; }
+  .stat-value.green { color: #059669; }
+  .svc-item { display: flex; align-items: flex-start; gap: 14px; padding: 16px 0; border-bottom: 1px solid #f3f4f6; }
+  .svc-item:last-child { border-bottom: none; }
+  .svc-icon { width: 40px; height: 40px; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-size: 20px; flex-shrink: 0; }
+  .svc-icon.blue { background: #eff6ff; }
+  .svc-icon.green { background: #ecfdf5; }
+  .svc-icon.purple { background: #eef2ff; }
+  .svc-body { flex: 1; min-width: 0; }
+  .svc-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .svc-name { font-size: 16px; font-weight: 700; color: #1f2937; }
+  .svc-desc { font-size: 14px; font-weight: 500; color: #6b7280; margin-top: 4px; }
+  .svc-meta { display: flex; gap: 16px; margin-top: 6px; flex-wrap: wrap; }
+  .svc-meta-item { font-size: 13px; font-weight: 600; color: #9ca3af; }
+  .svc-meta-item strong { color: #6b7280; font-weight: 700; }
+  .audit-table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 14px; }
+  .audit-table th { text-align: left; padding: 12px 10px; font-weight: 700; color: #6b7280; font-size: 13px; border-bottom: 2px solid #e8ecf1; }
+  .audit-table td { padding: 11px 10px; border-bottom: 1px solid #f3f4f6; font-weight: 600; color: #374151; font-family: "SF Mono","Fira Code",monospace; font-size: 13px; }
+  .audit-table tr:hover td { background: #fafbfc; }
+  .audit-svc { font-weight: 700; color: #1f2937; }
+  .badge { display: inline-block; padding: 4px 12px; border-radius: 20px; font-size: 13px; font-weight: 700; }
+  .badge-ok { background: #ecfdf5; color: #059669; }
+  .badge-err { background: #fef2f2; color: #dc2626; }
+  .refresh { text-align: center; margin-top: 20px; font-size: 14px; font-weight: 600; color: #9ca3af; }
+  .empty { text-align: center; padding: 32px; font-size: 15px; font-weight: 600; color: #9ca3af; }
+  .error-card { text-align: center; padding: 32px; }
+  .error-card p { color: #dc2626; font-weight: 600; margin-top: 8px; }
+</style>
+</head>
+<body>
+<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+  <h1>🦞 <span>P2P</span> Agent Network</h1>
+  <div style="display:flex;align-items:center;gap:12px;">
+    <span style="display:flex;align-items:center;gap:6px;font-size:14px;font-weight:700;color:#059669;">
+      <span style="width:10px;height:10px;border-radius:50%;background:#059669;display:inline-block;"></span> LIVE
+    </span>
+  </div>
+</div>
+<p class="sub" id="updateTime">正在连接网络...</p>
+<div class="nav">
+  <a href="/" class="active">📊 仪表盘</a>
+  <a href="/demo">🚀 交互演示</a>
+</div>
+<div class="grid" id="statusGrid"></div>
+<div class="card" style="margin-bottom:20px;">
+  <div class="card-header">
+    <span class="icon">🤖</span><h2>已注册 Agent</h2>
+    <span class="tag" id="svcCount">0</span>
+  </div>
+  <div id="services"></div>
+</div>
+<div class="card">
+  <div class="card-header">
+    <span class="icon">📋</span><h2>调用审计日志</h2>
+    <span class="tag">live</span>
+  </div>
+  <div id="audit"><div class="empty">loading...</div></div>
+</div>
+<div class="refresh" id="refreshInfo"></div>
+<script>
+async function load() {
+  try {
+    const r = await fetch('/api/status');
+    const d = await r.json();
+    const ts = d.timestamp;
+    document.getElementById('updateTime').textContent = '更新于 ' + ts + '  ·  每 5 秒自动刷新';
+
+    const cards = [
+      ['🌐','网络',[['Version',d.status.version,'highlight'],['直连 Peers',d.status.peers,''],
+        ['网络可见节点',d.status.overlay_peers||'—',''],['运行时长',d.status.uptime||'—',''],
+        ['DID',(d.status.did||'').substring(0,28)+'…','']]],
+      ['🆔','节点身份',[['Peer ID',(d.status.peer_id||'').substring(0,28)+'…',''],
+        ['余额',d.balance+' 🐚','green']]],
+      ['🤖','Agents',[['supplier-shenzhen','product_info','highlight'],
+        ['compliance-eu','compliance_check','highlight'],
+        ['logistics-shipper','shipping_quote','highlight']]],
+    ];
+    let gridHtml = '';
+    for (const [icon,title,rows] of cards) {
+      gridHtml += '<div class="card"><div class="card-header"><span class="icon">'+icon+'</span><h2>'+title+'</h2></div>';
+      for (const [label,value,cls] of rows)
+        gridHtml += '<div class="stat-row"><span class="stat-label">'+label+'</span><span class="stat-value'+(cls?' '+cls:'')+'">'+(value??'—')+'</span></div>';
+      gridHtml += '</div>';
+    }
+    document.getElementById('statusGrid').innerHTML = gridHtml;
+
+    let svcHtml = '';
+    if (d.services.length===0) svcHtml = '<div class="empty">网络上暂无已注册 Agent</div>';
+    else {
+      const icons=['blue','green','purple']; const emojis=['🔵','🟢','🟣'];
+      let idx=0;
+      for (const s of d.services) {
+        const ii=idx%3;
+        svcHtml += '<div class="svc-item"><div class="svc-icon '+icons[ii]+'">'+emojis[ii]+'</div>'+
+          '<div class="svc-body"><div class="svc-top"><span class="svc-name">'+s.name+'</span>'+
+          '<span class="badge '+(s.per_call>0?'badge-err':'badge-ok')+'">'+(s.per_call>0?s.per_call+'🐚/call':'免费')+'</span></div>'+
+          '<div class="svc-desc">'+s.description+'</div>'+
+          '<div class="svc-meta"><span class="svc-meta-item"><strong>Peer</strong> '+(s.peer_id||'').substring(0,18)+'…</span></div></div></div>';
+        idx++;
+      }
+    }
+    document.getElementById('services').innerHTML = svcHtml;
+    document.getElementById('svcCount').textContent = d.services.length + ' 个';
+
+    let auditHtml = '<table class="audit-table"><thead><tr><th>Service</th><th>Method</th><th>Path</th><th>Status</th><th>费用</th><th>耗时</th></tr></thead><tbody>';
+    if (d.audit.length===0) auditHtml += '<tr><td colspan="6"><div class="empty">暂无调用记录</div></td></tr>';
+    else {
+      for (const r of d.audit) {
+        const ok = r.status===200;
+        auditHtml += '<tr><td class="audit-svc">'+(r.service||'—')+'</td><td>'+(r.method||'—')+'</td><td>'+(r.path||'—')+'</td>'+
+          '<td><span class="badge '+(ok?'badge-ok':'badge-err')+'">'+(r.status??'—')+'</span></td>'+
+          '<td>'+(r.cost??'—')+'</td><td>'+(r.duration_ms?r.duration_ms+'ms':'—')+'</td></tr>';
+      }
+    }
+    auditHtml += '</tbody></table>';
+    document.getElementById('audit').innerHTML = auditHtml;
+    document.getElementById('refreshInfo').textContent = '上次更新: '+ts+'  ·  每 5 秒自动刷新';
+  } catch(e) {
+    document.getElementById('statusGrid').innerHTML =
+      '<div class="card error-card"><span style="font-size:48px;">⚠️</span><p>连接失败: '+e.message+'</p></div>';
+  }
+}
+load();
+setInterval(load,5000);
+</script>
+</body>
+</html>"""
+
+
+# ============================================================
+#  /demo — 一键傻瓜式演示
+# ============================================================
+
+DEMO_HTML = r"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P2P 跨境贸易协作平台</title>
+<style>
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{font-family:"PingFang SC","Microsoft YaHei",-apple-system,BlinkMacSystemFont,sans-serif;background:#f8f9fa;min-height:100vh;}
+  .top-bar{background:#fff;border-bottom:1px solid #e5e7eb;padding:16px 40px;display:flex;align-items:center;justify-content:space-between;}
+  .top-bar h1{font-size:20px;font-weight:800;color:#1f2937;}
+  .top-bar h1 span{color:#2563eb;}
+  .top-bar .status{font-size:13px;font-weight:600;color:#6b7280;display:flex;align-items:center;gap:6px;}
+  .top-bar .status .dot{width:8px;height:8px;border-radius:50%;background:#059669;display:inline-block;}
+  .container{max-width:960px;margin:0 auto;padding:32px 20px;}
+  .nav{display:flex;gap:12px;margin-bottom:24px;}
+  .nav a{padding:8px 20px;border-radius:8px;font-size:14px;font-weight:700;text-decoration:none;transition:all 0.2s;}
+  .nav a.active{background:#2563eb;color:#fff;}
+  .nav a:not(.active){background:#fff;color:#6b7280;border:1px solid #e5e7eb;}
+  .nav a:not(.active):hover{border-color:#2563eb;color:#2563eb;}
+  .input-box{background:#fff;border-radius:12px;padding:24px;border:1px solid #e5e7eb;margin-bottom:24px;}
+  .input-box h2{font-size:16px;font-weight:700;color:#1f2937;margin-bottom:16px;}
+  .input-row{display:flex;gap:12px;flex-wrap:wrap;align-items:end;}
+  .input-group{flex:1;min-width:140px;}
+  .input-group label{font-size:13px;font-weight:600;color:#6b7280;display:block;margin-bottom:4px;}
+  .input-group select,.input-group input{width:100%;padding:10px 14px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;font-weight:600;color:#1f2937;background:#fff;appearance:auto;}
+  .btn-start{padding:10px 32px;border:none;border-radius:8px;font-size:15px;font-weight:700;background:#2563eb;color:#fff;cursor:pointer;white-space:nowrap;transition:all 0.2s;}
+  .btn-start:hover{background:#1d4ed8;transform:translateY(-1px);}
+  .btn-start:disabled{background:#93c5fd;cursor:not-allowed;transform:none;}
+  .progress-wrap{background:#fff;border-radius:12px;border:1px solid #e5e7eb;padding:20px 24px;margin-bottom:20px;display:none;}
+  .progress-bar-bg{height:6px;background:#e5e7eb;border-radius:3px;overflow:hidden;margin-bottom:12px;}
+  .progress-bar-fill{height:100%;background:#2563eb;border-radius:3px;transition:width 0.5s;width:0%;}
+  .progress-label{font-size:14px;font-weight:600;color:#6b7280;display:flex;justify-content:space-between;}
+  .log-area{background:#fff;border-radius:12px;border:1px solid #e5e7eb;padding:20px 24px;display:none;margin-bottom:20px;max-height:320px;overflow-y:auto;}
+  .log-line{padding:6px 0;border-bottom:1px solid #f3f4f6;font-size:13px;color:#374151;display:flex;align-items:center;gap:8px;}
+  .log-line:last-child{border-bottom:none;}
+  .log-time{color:#9ca3af;font-family:monospace;font-size:12px;min-width:65px;}
+  .log-icon{min-width:22px;text-align:center;}
+  .log-msg{font-weight:500;}
+  .log-msg.ok{color:#059669;}
+  .log-msg.fail{color:#dc2626;}
+  .log-msg.highlight{color:#2563eb;font-weight:700;}
+  .result-area{display:none;}
+  .result-card{background:#fff;border-radius:12px;border:1px solid #e5e7eb;padding:24px;margin-bottom:16px;}
+  .result-card h3{font-size:15px;font-weight:700;color:#1f2937;margin-bottom:12px;display:flex;align-items:center;gap:8px;}
+  .result-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+  .result-item{background:#f9fafb;border-radius:8px;padding:14px;}
+  .result-item .label{font-size:12px;font-weight:600;color:#6b7280;}
+  .result-item .value{font-size:18px;font-weight:800;color:#1f2937;margin-top:2px;}
+  .result-item .value.green{color:#059669;}
+  .result-item .value.blue{color:#2563eb;}
+  .tag{display:inline-block;padding:3px 10px;border-radius:12px;font-size:12px;font-weight:600;margin:2px;}
+  .tag-ok{background:#dcfce7;color:#059669;}
+  .tag-fail{background:#fef2f2;color:#dc2626;}
+  .chain-box{background:#f0f5ff;border:1px solid #bfdbfe;border-radius:10px;padding:16px;text-align:center;margin-top:12px;}
+  .chain-box .chain{display:flex;align-items:center;justify-content:center;gap:6px;flex-wrap:wrap;}
+  .chain-box .step{background:#fff;border:2px solid #bfdbfe;border-radius:20px;padding:6px 16px;font-size:13px;font-weight:700;color:#2563eb;}
+  .chain-box .arrow{color:#93c5fd;font-size:16px;font-weight:700;}
+  .hidden{display:none;}
+</style>
+</head>
+<body>
+<div class="top-bar">
+  <h1>🌐 <span>P2P</span> 跨境贸易协作平台</h1>
+  <div class="status"><span class="dot"></span> 网络在线 · 3 家机构已接入</div>
+</div>
+<div class="container">
+  <div class="nav">
+    <a href="/">📊 仪表盘</a>
+    <a href="/demo" class="active">🚀 交互演示</a>
+  </div>
+  <div class="input-box">
+    <h2>📦 查询出口方案</h2>
+    <div class="input-row">
+      <div class="input-group">
+        <label>产品</label>
+        <select id="selProduct">
+          <option value="电动滑板车">电动滑板车</option>
+          <option value="蓝牙耳机">蓝牙耳机</option>
+          <option value="户外储能电源">户外储能电源</option>
+          <option value="儿童玩具车">儿童玩具车</option>
+          <option value="锂电池">锂电池</option>
+        </select>
+      </div>
+      <div class="input-group">
+        <label>数量</label>
+        <input type="number" id="inputQty" value="500" min="1">
+      </div>
+      <div class="input-group">
+        <label>目的港</label>
+        <select id="selDest">
+          <option value="汉堡">汉堡 (德国)</option>
+          <option value="鹿特丹">鹿特丹 (荷兰)</option>
+          <option value="热那亚">热那亚 (意大利)</option>
+        </select>
+      </div>
+      <button class="btn-start" id="btnStart" onclick="startDemo()">🚀 一键演示</button>
+    </div>
+  </div>
+  <div class="progress-wrap" id="progressWrap">
+    <div class="progress-bar-bg"><div class="progress-bar-fill" id="progressFill"></div></div>
+    <div class="progress-label"><span id="progressText">准备开始</span><span id="progressPct">0%</span></div>
+  </div>
+  <div class="log-area" id="logArea"></div>
+  <div class="result-area" id="resultArea"></div>
+</div>
+<script>
+function log(icon,msg,cls){const a=document.getElementById('logArea');a.style.display='block';
+  const t=new Date().toLocaleTimeString();const d=document.createElement('div');d.className='log-line';
+  d.innerHTML='<span class="log-time">'+t+'</span><span class="log-icon">'+icon+'</span><span class="log-msg '+(cls||'')+'">'+msg+'</span>';
+  a.appendChild(d);a.scrollTop=a.scrollHeight;}
+function setProgress(pct,text){document.getElementById('progressWrap').style.display='block';
+  document.getElementById('progressFill').style.width=pct+'%';document.getElementById('progressPct').textContent=pct+'%';
+  if(text)document.getElementById('progressText').textContent=text;}
+async function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
+async function callAPI(skill,path,body){
+  const r=await fetch('/api/demo/call',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({skill,path,body})});
+  return await r.json();}
+async function startDemo(){
+  const btn=document.getElementById('btnStart');const product=document.getElementById('selProduct').value;
+  const qty=parseInt(document.getElementById('inputQty').value)||500;const dest=document.getElementById('selDest').value;
+  btn.disabled=true;btn.textContent='⏳ 运行中...';
+  document.getElementById('logArea').innerHTML='';document.getElementById('logArea').style.display='none';
+  document.getElementById('resultArea').style.display='none';document.getElementById('resultArea').innerHTML='';
+  setProgress(5,'正在连接三家机构...');log('🔍','正在发现 Agent...','');
+  const disc=await callAPI('product_info','/v1/product/detail',{product});
+  if(disc.error){log('✗','发现失败: '+disc.error,'fail');btn.disabled=false;btn.textContent='🚀 一键演示';return;}
+  log('✅','发现 supplier-shenzhen (产品数据库)','ok');await sleep(400);
+  log('✅','发现 compliance-eu (法规数据库)','ok');await sleep(400);
+  log('✅','发现 logistics-shipper (运价数据库)','ok');
+  setProgress(20,'第 1/4 步 — 已发现 3 家机构');await sleep(600);
+  setProgress(35,'第 2/4 步 — 深圳工厂查询产品信息...');log('🏭','正在调用 supplier-shenzhen...','highlight');
+  const prod=disc;
+  if(prod.error){log('✗',prod.error,'fail');btn.disabled=false;btn.textContent='🚀 一键演示';return;}
+  log('📦','产品: '+prod.product+' | HS: '+prod.hs_code+' | 单价: $'+prod.price_usd,'');
+  log('📦','重量: '+prod.weight_kg+'kg | 产地: '+prod.origin+' | 证书: '+(prod.cert_have||[]).join(', '),'');await sleep(800);
+  setProgress(55,'第 3/4 步 — 欧盟合规部进行合规审查...');log('📋','正在调用 compliance-eu...','highlight');
+  const comp=await callAPI('compliance_check','/v1/compliance/check',{product_info:prod,product});
+  if(comp.error){log('✗',comp.error,'fail');btn.disabled=false;btn.textContent='🚀 一键演示';return;}
+  const passed=comp.regulations?comp.regulations.filter(r=>r.status.includes('已具备')).length:0;
+  const failed=comp.regulations?comp.regulations.filter(r=>r.status.includes('需要')).length:0;
+  log('📋','合规: '+comp.compliance_status+' | 通过: '+passed+'项 | 待办: '+failed+'项',comp.compliance_status.includes('合规')?'ok':'fail');
+  log('📋','预估费用: ¥'+(comp.estimated_compliance_cost_cny||0),'');await sleep(800);
+  setProgress(75,'第 4/4 步 — 国际货代计算物流费用...');log('🚢','正在调用 logistics-shipper...','highlight');
+  const ship=await callAPI('shipping_quote','/v1/shipping/quote',{product,qty,dest,product_info:prod});
+  if(ship.error){log('✗',ship.error,'fail');btn.disabled=false;btn.textContent='🚀 一键演示';return;}
+  log('🚢','路线: '+ship.route+' | '+ship.shipping_method+' | '+ship.transit_days+'天','');
+  log('🚢','海运费: $'+ship.freight_usd+' + 附加费: $'+(ship.surcharge_total_usd||0)+' = 总计: $'+ship.total_usd,'');
+  await sleep(600);setProgress(100,'✅ 演示完成！');log('🎉','三家机构数据已全部获取，生成诊断报告','ok');await sleep(500);
+  btn.textContent='🔄 重新演示';btn.disabled=false;showReport(prod,comp,ship,qty,dest);}
+function showReport(prod,comp,ship,qty,dest){
+  const unitPrice=prod.price_usd||0;const shipPerUnit=ship.cost_per_unit_usd||0;
+  const totalPerUnit=unitPrice+shipPerUnit;const totalCif=totalPerUnit*qty;const complianceCost=comp.estimated_compliance_cost_cny||0;
+  const regs=(comp.regulations||[]).map(r=>'<span class="tag '+(r.status.includes('已具备')?'tag-ok':'tag-fail')+'">'+r.regulation+' '+(r.status.includes('已具备')?'✅':'❌')+'</span>').join('');
+  const area=document.getElementById('resultArea');area.style.display='block';
+  area.innerHTML=`
+    <div class="result-card"><h3>📊 全链路诊断报告</h3>
+    <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:12px;margin-bottom:16px;">
+    <div style="font-weight:700;font-size:16px;color:#1f2937;">${prod.product} x ${qty} -> ${dest}</div>
+    <div style="font-size:13px;color:#6b7280;margin-top:4px;">HS: ${prod.hs_code} | 深圳工厂 · 欧盟合规部 · 国际货代</div></div>
+    <div class="result-grid">
+    <div class="result-item"><div class="label">💰 出厂单价</div><div class="value">$${unitPrice}</div></div>
+    <div class="result-item"><div class="label">🚢 单台运费</div><div class="value">$${shipPerUnit}</div></div>
+    <div class="result-item"><div class="label">📦 单台总成本</div><div class="value blue">$${totalPerUnit.toFixed(2)}</div></div>
+    <div class="result-item"><div class="label">🌍 整单到岸(CIF)</div><div class="value green">$${totalCif.toFixed(2)}</div></div>
+    </div></div>
+    <div class="result-card"><h3>📋 合规状况 · 预估费用 ¥${complianceCost}</h3>
+    <div style="margin-bottom:12px;">${regs}</div>
+    <div style="font-size:13px;color:#6b7280;">待办证书: ${failed}项 — 建议联系合规服务商办理</div></div>
+    <div class="result-card"><h3>🚢 物流方案</h3>
+    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;">
+    <div><div class="label">路线</div><div style="font-weight:700;">${ship.route}</div></div>
+    <div><div class="label">方式</div><div style="font-weight:700;">${ship.shipping_method}</div></div>
+    <div><div class="label">运输时间</div><div style="font-weight:700;">${ship.transit_days}天</div></div>
+    </div><div style="margin-top:12px;font-size:13px;color:#6b7280;">
+    海运费: $${ship.freight_usd} | 附加费: $${ship.surcharge_total_usd||0} | <strong>总运费: $${ship.total_usd}</strong>
+    </div></div>
+    <div class="result-card" style="border-color:#bfdbfe;background:#f8faff;"><h3>🔗 信息差桥接链路</h3>
+    <div class="chain-box"><div class="chain">
+    <span class="step">🖥️ Client</span><span class="arrow">-></span><span class="step">🏭 深圳工厂</span>
+    <span class="arrow">-></span><span class="step">📋 欧盟合规部</span><span class="arrow">-></span><span class="step">🚢 国际货代</span>
+    </div><div style="margin-top:10px;font-size:13px;font-weight:600;color:#6b7280;">
+    三家机构各自持有不同数据 · 通过 P2P 网络协作 · 数据不出本方网络</div></div></div>`;}
+</script>
+</body>
+</html>"""
+
+
+# ============================================================
+#  API
+# ============================================================
+
+def get_status() -> dict[str, Any]:
+    try:
+        r = httpx.get(f"{BASE_URL}/api/status",
+                      headers={"Authorization": f"Bearer {TOKEN}"}, timeout=3.0)
+        if r.status_code == 200: return r.json()
+        return {"error": f"HTTP {r.status_code}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_balance() -> str:
+    try:
+        r = httpx.get(f"{BASE_URL}/api/credits/balance",
+                      headers={"Authorization": f"Bearer {TOKEN}"}, timeout=3.0)
+        if r.status_code == 200: return str(r.json().get("shell_balance", "?"))
+        return "?"
+    except Exception:
+        return "?"
+
+def discover_services() -> list[dict]:
+    services = []
+    try:
+        svc = SvcClient(base_url=CALL_BASE_URL, token=CALL_TOKEN)
+        for skill in SKILLS:
+            peers = svc.discover(skill=skill)
+            for p in peers:
+                for s in p.get("services", []):
+                    cost = s.get("cost_model", {}).get("per_call", 0)
+                    services.append({
+                        "name": s["name"], "peer_id": p["peer_id"],
+                        "description": s.get("description", ""),
+                        "per_call": cost, "modes": s.get("modes", []),
+                        "paths": [x.get("prefix", "") for x in s.get("paths", [])],
+                    })
+        svc.close()
+    except Exception as e:
+        return [{"name": f"error: {e}", "peer_id": "", "description": "", "per_call": 0}]
+    return services
+
+def get_audit() -> list[dict]:
+    try:
+        svc = SvcClient(base_url=CALL_BASE_URL, token=CALL_TOKEN)
+        rows = svc.audit(limit=10)
+        svc.close()
+        return rows
+    except Exception:
+        return []
+
+
+@app.get("/api/status")
+def api_status():
+    s = get_status()
+    return {
+        "timestamp": time.strftime("%H:%M:%S"),
+        "status": {
+            "version": s.get("version", "?"), "did": s.get("did", "?"),
+            "peer_id": s.get("peer_id", "?"), "peers": s.get("peers", "?"),
+            "overlay_peers": s.get("overlay_peers", "?"), "uptime": s.get("uptime", "?"),
+        },
+        "balance": get_balance(), "services": discover_services(), "audit": get_audit(),
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard():
+    return DASH_HTML
+
+
+@app.get("/demo", response_class=HTMLResponse)
+def demo_page():
+    return DEMO_HTML
+
+
+@app.post("/api/demo/call")
+def demo_call(body: dict):
+    skill = body.get("skill", ""); path = body.get("path", ""); call_body = body.get("body", {})
+    try:
+        svc = SvcClient(base_url=CALL_BASE_URL, token=CALL_TOKEN)
+        peers = svc.discover(skill=skill)
+        if not peers: return {"error": f"未找到 skill={skill} 的 Agent"}
+        target = peers[0]
+        resp = svc.call(target["peer_id"], target["services"][0]["name"],
+                        path, method="POST", body=call_body)
+        svc.close()
+        result = resp.get("body") or {}
+        if isinstance(result, str):
+            try: result = json.loads(result)
+            except json.JSONDecodeError: pass
+        return result
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main():
+    print(f"[dashboard] http://127.0.0.1:{DASH_PORT}")
+    print(f"[demo]      http://127.0.0.1:{DASH_PORT}/demo")
+    uvicorn.run(app, host="127.0.0.1", port=DASH_PORT, log_level="warning")
+
+if __name__ == "__main__":
+    main()

--- a/p2p/starter-template/start.command
+++ b/p2p/starter-template/start.command
@@ -1,0 +1,230 @@
+#!/bin/bash
+# ============================================================
+#  P2P 跨境贸易演示 — 双击一键启动
+#  适用: macOS (双击此文件 → 自动运行)
+#  适用: Linux (bash start.sh)
+# ============================================================
+
+# 出错继续执行（不中断）
+set +e
+
+# 获取脚本所在目录
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+# 终端标题
+echo -e "\033[1;36m"
+echo "  ╔══════════════════════════════════════════════╗"
+echo "  ║     🌐  P2P 跨境贸易协作平台                 ║"
+echo "  ║     双击启动 · 全自动安装运行                ║"
+echo "  ╚══════════════════════════════════════════════╝"
+echo -e "\033[0m"
+
+# ============================================================
+# 第 1 步: 检查/安装 anet CLI
+# ============================================================
+echo ""
+echo "  >>> [1/6] 检查 anet CLI..."
+
+if command -v anet &>/dev/null 2>&1; then
+    VER=$(anet --version 2>/dev/null || echo "ok")
+    echo "  ✓ anet $VER"
+else
+    echo "  → 正在安装 anet (需要输入密码)..."
+    curl -fsSL https://agentnetwork.org.cn/install.sh | sh
+    # 刷新 PATH
+    export PATH="$HOME/.local/bin:$PATH"
+    if command -v anet &>/dev/null 2>&1; then
+        echo "  ✓ anet 安装成功"
+    else
+        echo "  ✗ anet 安装失败，请手动执行: curl -fsSL https://agentnetwork.org.cn/install.sh | sh"
+        read -p "  按回车退出..."
+        exit 1
+    fi
+fi
+
+# ============================================================
+# 第 2 步: 检查 Python 依赖
+# ============================================================
+echo ""
+echo "  >>> [2/6] 检查 Python 环境..."
+
+PYTHON="python3"
+# 检查必要包
+$PYTHON -c "import anet, fastapi, uvicorn" 2>/dev/null
+if [ $? -ne 0 ]; then
+    echo "  → 安装 Python 依赖..."
+    $PYTHON -m pip install -q anet fastapi uvicorn httpx --break-system-packages 2>/dev/null || \
+    $PYTHON -m pip install -q anet fastapi uvicorn httpx
+    sleep 2
+fi
+echo "  ✓ Python 依赖就绪"
+
+# ============================================================
+# 第 3 步: 启动两个本地 daemon
+# ============================================================
+echo ""
+echo "  >>> [3/6] 启动 P2P 节点..."
+
+# 清理残留
+for PORT in 13921 13922; do
+    PID=$(lsof -ti tcp:$PORT 2>/dev/null || true)
+    if [ -n "$PID" ]; then
+        kill -9 "$PID" 2>/dev/null || true
+    fi
+done
+rm -rf /tmp/anet-p2p-u1 /tmp/anet-p2p-u2
+sleep 1
+
+# 启动 daemon-1
+echo "  → 启动节点 1 (:13921)..."
+nohup anet daemon --api-listen :13921 --p2p-port 14021 \
+    --home /tmp/anet-p2p-u1 > /tmp/anet-daemon1.log 2>&1 &
+
+# 等待就绪
+for i in $(seq 1 20); do
+    if [ -f /tmp/anet-p2p-u1/.anet/api_token ]; then
+        break
+    fi
+    sleep 1
+done
+if [ ! -f /tmp/anet-p2p-u1/.anet/api_token ]; then
+    echo "  ✗ 节点 1 启动失败"
+    tail -5 /tmp/anet-daemon1.log
+    read -p "  按回车退出..."
+    exit 1
+fi
+echo "  ✓ 节点 1 就绪 (:13921)"
+
+# 启动 daemon-2
+echo "  → 启动节点 2 (:13922)..."
+nohup anet daemon --api-listen :13922 --p2p-port 14022 \
+    --home /tmp/anet-p2p-u2 > /tmp/anet-daemon2.log 2>&1 &
+
+for i in $(seq 1 20); do
+    if [ -f /tmp/anet-p2p-u2/.anet/api_token ]; then
+        break
+    fi
+    sleep 1
+done
+if [ ! -f /tmp/anet-p2p-u2/.anet/api_token ]; then
+    echo "  ✗ 节点 2 启动失败"
+    tail -5 /tmp/anet-daemon2.log
+    read -p "  按回车退出..."
+    exit 1
+fi
+echo "  ✓ 节点 2 就绪 (:13922)"
+
+# ============================================================
+# 第 4 步: 跨节点转账
+# ============================================================
+echo ""
+echo "  >>> [4/6] 配置网络..."
+
+TOKEN1=$(tr -d '[:space:]' < /tmp/anet-p2p-u1/.anet/api_token)
+TOKEN2=$(tr -d '[:space:]' < /tmp/anet-p2p-u2/.anet/api_token)
+DID1=$(ANET_TOKEN=$TOKEN1 anet status 2>/dev/null | grep "did:" | head -1 | awk '{print $2}')
+DID2=$(ANET_TOKEN=$TOKEN2 anet status 2>/dev/null | grep "did:" | head -1 | awk '{print $2}')
+
+if [ -n "$DID1" ] && [ -n "$DID2" ]; then
+    curl -s -X POST http://127.0.0.1:13921/api/credits/transfer \
+        -H "Authorization: Bearer $TOKEN1" -H "Content-Type: application/json" \
+        -d "{\"from\":\"$DID1\",\"to\":\"$DID2\",\"amount\":1000,\"reason\":\"seed\"}" &>/dev/null || true
+    curl -s -X POST http://127.0.0.1:13922/api/credits/transfer \
+        -H "Authorization: Bearer $TOKEN2" -H "Content-Type: application/json" \
+        -d "{\"from\":\"$DID2\",\"to\":\"$DID1\",\"amount\":1000,\"reason\":\"seed\"}" &>/dev/null || true
+    echo "  ✓ 网络配置完成"
+fi
+
+# ============================================================
+# 第 5 步: 启动三个 Agent
+# ============================================================
+echo ""
+echo "  >>> [5/6] 注册 Agent..."
+
+# 清理旧注册
+for name in supplier-shenzhen compliance-eu logistics-shipper; do
+    ANET_TOKEN=$TOKEN1 python3 -c "
+from anet.svc import SvcClient
+try: SvcClient(base_url='http://127.0.0.1:13921').unregister('$name')
+except: pass" 2>/dev/null || true
+done
+
+for PORT in 7411 7412 7413; do
+    lsof -ti tcp:$PORT 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
+sleep 1
+
+# 供应商
+echo "  → 深圳工厂..."
+PYTHONPATH="$DIR" nohup $PYTHON -u "$DIR/my_team/agents/agent_a_supplier.py" > /tmp/agent_supplier.log 2>&1 &
+sleep 3
+if grep -q "published=True" /tmp/agent_supplier.log 2>/dev/null; then
+    echo "  ✓ 深圳工厂 上线"
+else
+    echo "  ✗ 深圳工厂 注册失败"
+    tail -3 /tmp/agent_supplier.log
+fi
+
+# 合规
+echo "  → 欧盟合规..."
+PYTHONPATH="$DIR" nohup $PYTHON -u "$DIR/my_team/agents/agent_b_compliance.py" > /tmp/agent_compliance.log 2>&1 &
+sleep 3
+if grep -q "published=True" /tmp/agent_compliance.log 2>/dev/null; then
+    echo "  ✓ 欧盟合规 上线"
+else
+    echo "  ✗ 欧盟合规 注册失败"
+    tail -3 /tmp/agent_compliance.log
+fi
+
+# 物流
+echo "  → 国际货代..."
+PYTHONPATH="$DIR" nohup $PYTHON -u "$DIR/my_team/agents/agent_c_logistics.py" > /tmp/agent_logistics.log 2>&1 &
+sleep 3
+if grep -q "published=True" /tmp/agent_logistics.log 2>/dev/null; then
+    echo "  ✓ 国际货代 上线"
+else
+    echo "  ✗ 国际货代 注册失败"
+    tail -3 /tmp/agent_logistics.log
+fi
+
+# ============================================================
+# 第 6 步: 启动 Dashboard + 打开浏览器
+# ============================================================
+echo ""
+echo "  >>> [6/6] 启动控制台..."
+
+lsof -ti tcp:7500 2>/dev/null | xargs kill -9 2>/dev/null || true
+sleep 1
+
+PYTHONPATH="$DIR" nohup $PYTHON -u "$DIR/my_team/dashboard.py" > /tmp/dashboard.log 2>&1 &
+sleep 2
+
+echo ""
+echo "  ╔══════════════════════════════════════════════╗"
+echo "  ║        ✅  启动完成！                       ║"
+echo "  ╠══════════════════════════════════════════════╣"
+echo "  ║                                              ║"
+echo "  ║   🚀 交互演示                                ║"
+echo "  ║   http://127.0.0.1:7500/demo                ║"
+echo "  ║                                              ║"
+echo "  ║   📊 仪表盘                                  ║"
+echo "  ║   http://127.0.0.1:7500                     ║"
+echo "  ║                                              ║"
+echo "  ║   在线 Agent:                                ║"
+echo "  ║   🏭 深圳工厂 · 📋 欧盟合规 · 🚢 国际货代  ║"
+echo "  ║                                              ║"
+echo "  ║   关闭此窗口 = 停止所有服务                   ║"
+echo "  ╚══════════════════════════════════════════════╝"
+echo ""
+
+# 打开浏览器
+if command -v open &>/dev/null; then
+    open http://127.0.0.1:7500/demo
+elif command -v xdg-open &>/dev/null; then
+    xdg-open http://127.0.0.1:7500/demo
+fi
+
+# 保持窗口打开
+echo "  按 Ctrl+C 停止所有服务并关闭"
+wait

--- a/p2p/starter-template/stop.sh
+++ b/p2p/starter-template/stop.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# 停止所有 P2P 演示相关进程
+set -euo pipefail
+echo "→ 停止 Agent..."
+pkill -f agent_a_supplier 2>/dev/null || true
+pkill -f agent_b_compliance 2>/dev/null || true
+pkill -f agent_c_logistics 2>/dev/null || true
+pkill -f dashboard.py 2>/dev/null || true
+echo "→ 停止 daemon..."
+pkill -f "anet daemon" 2>/dev/null || true
+lsof -ti tcp:13921,13922,13923,13924 2>/dev/null | xargs kill -9 2>/dev/null || true
+lsof -ti tcp:7411,7412,7413,7500 2>/dev/null | xargs kill -9 2>/dev/null || true
+sleep 2
+echo "✓ 已停止所有进程"


### PR DESCRIPTION
## 新增内容

三个 P2P Agent，跨境电商出口合规场景：

| Agent | Skill | 数据 |
|---|---|---|
| supplier-shenzhen | product_info | 5款产品规格/HS编码/报价 |
| compliance-eu | compliance_check | 11项欧盟法规 (RoHS/REACH/CBAM/PFAS/TSR…) |
| logistics-shipper | shipping_quote | 中国→欧洲5条航线运价 |

### 包含文件
- `p2p/starter-template/my_team/agents/` — 三个 Agent + 注册工具
- `p2p/starter-template/my_team/dashboard.py` — Web 仪表盘 + 交互演示
- `p2p/starter-template/start.command` — 双击一键启动
- `p2p/starter-template/stop.sh` — 一键停止
- `p2p/starter-template/SOP.md` — 标准操作流程

### 使用方法
```bash
bash p2p/starter-template/start.command
# 浏览器打开 http://127.0.0.1:7500/demo
```