### PR TITLE
feat(p2p): add api-zhuanzhuan — key bank on AgentNetwork

### DIFF
--- a/p2p/api-zhuanzhuan/.env.example
+++ b/p2p/api-zhuanzhuan/.env.example
@@ -1,0 +1,17 @@
+APP_NAME=api-zhuanzhuan
+APP_API_KEY=change-me-to-a-long-random-string
+
+# anet daemon REST（先 `anet daemon &` 启动）
+AGENT_NET_ENDPOINT=http://127.0.0.1:3998
+# 留空时 SDK 自动从 ~/.anet/api_token 或 $ANET_TOKEN 取
+AGENT_NET_TOKEN=
+
+HOST=0.0.0.0
+PORT=8088
+# 注册到 AgentNetwork 时告诉别的 peer 怎么回调你（局域网/公网地址）
+PUBLIC_ENDPOINT=http://127.0.0.1:8088
+
+# 逗号分隔的可中转目标 peer_id；留空=不限制
+ALLOWED_PEERS=
+
+CALL_TIMEOUT=60

--- a/p2p/api-zhuanzhuan/.gitignore
+++ b/p2p/api-zhuanzhuan/.gitignore
@@ -1,0 +1,26 @@
+# secrets
+.env
+*.local
+
+# runtime data (contains real API keys in plaintext)
+data/*.json
+!data/.gitkeep
+
+# logs / pid
+*.log
+*.pid
+
+# python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# macOS
+.DS_Store
+
+# editors
+.vscode/
+.idea/
+*.swp

--- a/p2p/api-zhuanzhuan/Dockerfile
+++ b/p2p/api-zhuanzhuan/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV HOST=0.0.0.0 PORT=8080
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/p2p/api-zhuanzhuan/HANDOFF.md
+++ b/p2p/api-zhuanzhuan/HANDOFF.md
@@ -1,0 +1,307 @@
+# HANDOFF — API 转转 交接文档
+
+> **交接对象**：下一位接手的开发者
+> **最后更新**：2026-05-02
+> **当前状态**：已上线 anet 主网，功能可用
+
+---
+
+## 1. 这个项目是干嘛的
+
+一句话：**key 托管所**，在 AgentNetwork 上跑一个 FastAPI 服务，帮 agent 之间互相"存/借" API key。
+
+### 业务规则（要熟记）
+
+| 规则 | 说明 |
+|---|---|
+| **先存才能借** | DID 必须至少 deposit 过一次，才能调 `/lease`。非会员调 `/lease` → 403 |
+| **一次性** | 每把 key 被 `/lease` 命中一次后 status 从 `available` 变 `leased`，从可借池消失 |
+| **备份永留** | 被借走的 key 不会删除，`bank.json > leases` 里永久保留 snapshot 和调用链 |
+| **不能自借** | 如果借用者是 key 的 provider，本笔 deposit 跳过（避免自己借自己） |
+| **~~上游验证~~** | **已关**（见 §5）。deposit 不再调上游握手，任意 key 秒过 |
+
+### 不是什么（避免误解）
+
+- ❌ 不是 LLM 代理（不转发请求到上游）
+- ❌ 不是账本（没有余额、没有计费、没有 credit）
+- ❌ 不是网关（不解包、不改包、不鉴权上游）
+- ✅ 就是个**带会员制的 key 保管箱**
+
+---
+
+## 2. 架构 & 文件职责
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  anet daemon (Go, 独立进程)                                  │
+│   - REST   :3998    ← 本地业务进程用这个                        │
+│   - libp2p :4001    ← peer 间 P2P                          │
+│   - 作用：注册发现 / P2P 路由 / 身份注入                          │
+└────────────┬───────────────────────────────────────────────┘
+             │  反代（把 P2P 入站请求映射到本地 HTTP endpoint）
+             ▼
+┌────────────────────────────────────────────────────────────┐
+│  bank (FastAPI, 本项目)                                      │
+│   - :7200                                                    │
+│   - llm_backend.py  ← 路由层（HTTP handlers）                  │
+│   - bank.py         ← 业务层（deposit/lease/audit）            │
+│   - data/bank.json  ← 持久化（JSON，atomic write）             │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 文件清单（新架构 — 实际在用）
+
+| 文件 | 职责 | 关键代码 |
+|---|---|---|
+| `bank.py` | 业务核心 | `Bank.deposit()`, `Bank.lease()`, `Bank.audit()`, `Bank.list_deposits_safe()` |
+| `llm_backend.py` | FastAPI 路由 | 只做参数校验 + 转发到 `Bank` 方法 |
+| `register_llm.py` | 注册脚本 | 启动时调 `SvcClient.register()` 把 bank 挂到 daemon |
+| `run.sh` | 生命周期 | `./run.sh {start\|stop\|status\|logs}` |
+| `requirements.txt` | 依赖 | fastapi / uvicorn / pydantic / anet-sdk |
+| `.env.example` | 环境变量模板 | 实际 `.env` 不入库 |
+| `data/bank.json` | 数据库 | **不入库**（含明文 key） |
+
+### 文件清单（遗留 — 旧架构残留，没人 import）
+
+> 这些是上一版 "relay agent / 账本" 架构的文件，**新 bank 完全不用**。
+> 交接保留是为了历史参考。可以安全删除，但先问清楚 owner。
+
+| 文件 | 旧用途 |
+|---|---|
+| `main.py` | 老 FastAPI 入口（relay agent） |
+| `router.py` | 老 `SvcClient` 封装 |
+| `registrar.py` | 老注册逻辑 |
+| `config.py` | 老环境变量加载 |
+| `ledger.py` | 老账本（credit 计费） |
+| `key_pool.py` | 老 key 池 |
+| `Dockerfile` | 给老 main.py 用的 |
+| `docker-compose.yml` | 同上 |
+| `data/ledger.json` | 老账本数据（不入库） |
+| `data/key_pool.json` | 老 key 池数据（不入库） |
+
+---
+
+## 3. 数据模型
+
+`data/bank.json` 结构：
+
+```json
+{
+  "deposits": {
+    "dep_3c1ca33a12ce": {
+      "deposit_id": "dep_3c1ca33a12ce",
+      "provider_did": "did:key:z6Mk...",
+      "api_key":      "sk-...",
+      "base_url":     "https://api.openai-next.com",
+      "model":        "claude-opus-4-7",
+      "status":       "available" | "leased",
+      "deposited_at": 1777694299.08
+    }
+  },
+  "leases": [
+    {
+      "lease_id":     "lease_84eda8c31a6e",
+      "deposit_id":   "dep_3c1ca33a12ce",
+      "borrower_did": "did:key:z6Mk...",
+      "provider_did": "did:key:z6Mk...",
+      "leased_at":    1777695477.31,
+      "snapshot":     { "api_key": "sk-...", "base_url": "...", "model": "..." }
+    }
+  ],
+  "members": {
+    "did:key:z6Mk...": { "first_deposit_at": 1777694299.08, "total_deposits": 3 }
+  }
+}
+```
+
+并发：`bank.py` 里用 `threading.Lock()` 保护 `_data`，写盘用 `tmp + replace` 原子操作。**单进程**，扩容到多进程要换存储（SQLite / Postgres）。
+
+---
+
+## 4. 部署与运维
+
+### 当前部署位置
+
+- **机器**：`edy` 的 Mac (Apple Silicon, Darwin 24.6.0)
+- **bank 进程**：监听 `127.0.0.1:7200`，pid 在 `/tmp/api-zhuanzhuan-bank.pid`
+- **bank 日志**：`/tmp/api-zhuanzhuan-bank.log`
+- **数据文件**：`/Users/edy/Desktop/API转转/data/bank.json` ⚠️ **路径硬编码**（见 §6 坑位）
+- **anet daemon**：系统主 daemon（pid 40665），REST `:3998`，libp2p `:4001`
+- **daemon 身份**：
+  - DID: `did:key:z6MkjQFXgSHprJXYwdHWBZjNVQe73fsEQpzhLy9cJDDXuU7T`
+  - peer_id: `12D3KooWEmMeqKd6hfJaF1xE8bWsR7AwiRe22dppcYbhqvQQtC41`
+- **ANS**: `agent://svc/api-zhuanzhuan-bank-6c7c3d36`
+
+### 启停
+
+```bash
+./run.sh start    # 起 bank + 注册到 daemon
+./run.sh stop     # kill 进程（不 unregister — 见 §6）
+./run.sh status   # 看 pid + health
+./run.sh logs     # tail -f 日志
+```
+
+### 重新注册到主 daemon（换机器或改了 description 后）
+
+```bash
+ANET_BASE_URL=http://127.0.0.1:3998 \
+ANET_TOKEN=$(cat ~/.anet/api_token) \
+BANK_PORT=7200 \
+python3 register_llm.py
+```
+
+### 常用 curl
+
+```bash
+# 健康
+curl http://127.0.0.1:7200/health
+
+# 存
+curl -X POST http://127.0.0.1:7200/deposit \
+  -H "Content-Type: application/json" \
+  -H "X-Agent-DID: did:key:tester" \
+  -d '{"api_key":"sk-xxx","base_url":"https://api.openai-next.com","model":"claude-opus-4-7"}'
+
+# 借
+curl -X POST http://127.0.0.1:7200/lease \
+  -H "X-Agent-DID: did:key:tester"
+
+# 审计
+curl http://127.0.0.1:7200/audit
+```
+
+---
+
+## 5. 功能变更记录
+
+| 日期 | 变更 | 原因 |
+|---|---|---|
+| 初版 | deposit 前调上游 `/v1/messages` 握手验证 | 想过滤无效 key |
+| 2026-05-02 | **关闭上游验证** | 部分合法 key 因网络超时被误拒（"握手失败"），业务方决定"信任提交方" |
+
+**代码上的痕迹**：`bank.py` 里 `httpx` import 已删，`verify_key()` 方法已删。如果以后要恢复验证，参考 git log。
+
+---
+
+## 6. 已知坑 / TODO（按优先级）
+
+### 🔴 P0 — 必须修
+
+1. **api_key 明文存盘**
+   `data/bank.json` 里所有 `api_key` 是明文，`leases[].snapshot.api_key` 也是一份。磁盘/备份/日志任何一处漏掉就全裸奔。
+   **建议**：用 `keyring` / `age` / 对称加密，至少别明文。
+
+2. **`.env` 真 token 泄露风险**
+   `.env` 里曾经有 `AGENT_NET_TOKEN=40426cfb...`（本机 daemon 真 token）。已 `.gitignore`，但本地副本还在。换人接手时要 rotate 一次。
+
+3. **bank.py 路径硬编码**
+   `BANK_PATH = /Users/edy/Desktop/API转转/data/bank.json`（bank.py:19），换机器直接挂。
+   **建议**：改成 `Path(__file__).parent / "data/bank.json"` 或读 env。
+
+### 🟡 P1 — 尽快修
+
+4. **停止时不 unregister**
+   `./run.sh stop` 只 kill bank 进程，不通知 daemon 摘掉注册。daemon 会显示服务"unhealthy"直到超时。
+   **建议**：在 `llm_backend.py` 加 `@app.on_event("shutdown")` 或 signal handler，调 `svc.unregister()`。
+
+5. **DID 身份不校验**
+   bank 信任 header `X-Agent-DID`。走 anet daemon 反代时 daemon 会注入真实调用方 DID，没问题；但**如果有人直接打 7200 端口**（bind 是 `127.0.0.1`，要 SSH/其它本地进程），随便填 DID 就能当会员。
+   **建议**：校验请求来源（只接受 daemon 反代的 UA/signature），或 daemon 签身份 JWT。
+
+6. **重复注册**
+   历史上在 u1/u2/u3 测试 daemon 上也注册过，`discover(skill="key-bank")` 会返回重复的 ans。
+   **建议**：写个清理脚本 unregister 掉孤岛注册。
+
+### 🟢 P2 — 可以不急
+
+7. **单进程 + JSON 存储**
+   不能水平扩容。并发量上来要换 SQLite / Postgres。
+
+8. **没有限流**
+   理论上一个会员能 `/lease` 到把池抽干。
+   **建议**：每 DID 每天借 N 把、冷却时间等。
+
+9. **verify_key 已删，要恢复怎么办**
+   上游对不同家（Anthropic / OpenAI / Gemini）格式不一样，旧版固定用 Anthropic `/v1/messages` 格式恰好被 `openai-next.com` 这个中转站兼容了。要恢复验证得写 adapter。
+
+---
+
+## 7. anet 集成要点
+
+### SDK 关键方法（`anet.svc.SvcClient`）
+
+```python
+# 初始化（不传 token 会从 ~/.anet/api_token 读）
+c = SvcClient("http://127.0.0.1:3998", token)
+
+# 注册（启动时）
+c.register(name="api-zhuanzhuan-bank", endpoint="http://127.0.0.1:7200",
+           paths=["/deposit", "/lease", "/audit", "/deposits", "/health", "/meta"],
+           modes=["rr"], free=True,
+           tags=["key-bank", "api-zhuanzhuan", "deposit-lease"],
+           description="...", health_check="/health", meta_path="/meta")
+
+# 发现
+peers = c.discover(skill="key-bank")  # 返回 [{peer_id, owner_did, ans_name, services:[...]}]
+
+# 调用（从 B 的角度）
+r = c.call(peer_id, "api-zhuanzhuan-bank", "/deposit",
+           body={"api_key":"...", ...})
+# r = {"status":200, "headers":{...}, "body":{...}}
+
+# 关服
+c.unregister("api-zhuanzhuan-bank")
+```
+
+### 关键行为（踩坑经验）
+
+- **`SvcClient.call(headers=...)`** 传的 headers **不会透传给上游** HTTP endpoint。daemon 只帮你注入 `X-Agent-DID`，其他 header（如自定义 Authorization）到不了 bank。**业务参数用 body 传，不要用 header。**
+- **`dial to self attempted`**：同一个 daemon 上的 agent 想 call 它自己注册的服务，libp2p 会拒。只能跨 daemon 测。
+- **P2P 发现依赖 bootstrap**：`config.json` 里 `bootstrap_peers: []` 是孤岛模式。系统主 daemon（`~/.anet/`）接了公共 bootstrap，自带 DHT；测试用的 `/tmp/anet-p2p-u1/` daemon 是孤岛，**只能同机 u1/u2/u3 互通**。
+
+---
+
+## 8. 怎么验证当前部署是活的
+
+```bash
+# 1. 主 daemon 里能看到 bank
+python3 <<'EOF'
+from anet.svc import SvcClient
+t = open("/Users/edy/.anet/api_token").read().strip()
+c = SvcClient("http://127.0.0.1:3998", t)
+for s in c.list():
+    print(s["name"], "→", s["endpoint"])
+EOF
+
+# 2. 全网 discover 能找到
+python3 -c "
+from anet.svc import SvcClient
+t = open('/Users/edy/.anet/api_token').read().strip()
+c = SvcClient('http://127.0.0.1:3998', t)
+for p in c.discover(skill='key-bank'):
+    print(p['ans_name'])
+"
+
+# 3. bank 直接 health
+curl http://127.0.0.1:7200/health
+```
+
+预期输出都有 `api-zhuanzhuan-bank` 相关条目。
+
+---
+
+## 9. 联系/提问
+
+- anet SDK 问题：看 `sdk/` 目录或 https://github.com/zeenaz/Agent-Network-P2P-Service
+- anet daemon 问题：`anet help` / `anet status`
+- 业务规则问题：看本文 §1 / bank.py 顶部 docstring
+
+**交接 checklist**（下一位接手时过一遍）：
+
+- [ ] 本文读完
+- [ ] `./run.sh start` 能起来
+- [ ] 能访问 `http://127.0.0.1:7200/health` 返回 `{"ok":true, ...}`
+- [ ] `anet status` 有本机主 daemon 在跑
+- [ ] `discover(skill="key-bank")` 能看到 `-6c7c3d36` 或新生成的 ans
+- [ ] 跑一遍 `deposit → lease` 流程验证功能
+- [ ] 理解 §6 P0 三个坑

--- a/p2p/api-zhuanzhuan/README.md
+++ b/p2p/api-zhuanzhuan/README.md
@@ -1,0 +1,80 @@
+# API 转转 (API Zhuan Zhuan) — Key Bank on AgentNetwork
+
+一个跑在 **AgentNetwork (anet)** 上的 API key 托管服务。
+
+**模式**：存借制 + 一次性租用
+- **A 存 key**（`POST /deposit`）→ 成为会员，key 进入可借池
+- **B 借 key**（`POST /lease`）→ 必须先存过（会员制），拿到别人的 key 后该 key 从池中移除（阅后即焚），但备份永留数据库
+
+```
+A ──┐                    ┌── lease ──▶ B
+    │   anet P2P 网络    │   (拿到 key + base_url + model)
+    └─▶  api-zhuanzhuan  ─┘
+         bank (本机 127.0.0.1:7200)
+         注册名: api-zhuanzhuan-bank
+```
+
+## 一句话原理
+
+bank 是一个普通 FastAPI 服务，通过 `anet-sdk` 的 `svc.register()` 挂到本机 anet daemon 上。调用方不用知道 bank 在哪台机器，只要连到 anet 主网就能 `discover(skill="key-bank")` 找到它。
+
+## 跑起来（3 步）
+
+```bash
+# 1. 确保本机 anet daemon 在跑（REST 默认 :3998）
+anet status
+
+# 2. 起 bank + 自动注册到 daemon
+./run.sh start
+
+# 3. 检查
+./run.sh status   # 应该返回 {"ok":true, ...}
+```
+
+## 对外接口（被其他 agent 调用）
+
+| path | 方法 | 说明 |
+|---|---|---|
+| `/deposit` | POST | A 存 key，body: `{api_key, base_url, model}` |
+| `/lease`   | POST | B 借 key（只有会员能借，且不能借自己的） |
+| `/audit`   | GET | 全部记录（所有 deposit + lease） |
+| `/deposits`| GET | 可借库存（脱敏） |
+| `/health`  | GET | 健康检查 |
+| `/meta`    | GET | 服务元信息 |
+
+所有 `/deposit` 和 `/lease` 请求必须带 header：`X-Agent-DID: did:key:...`（anet daemon 反代时会自动注入调用方身份）。
+
+## 别人怎么用我（作为 B 接入）
+
+```python
+from anet.svc import SvcClient
+c = SvcClient("http://127.0.0.1:3998", open("~/.anet/api_token").read().strip())
+
+peer = c.discover(skill="key-bank")[0]["peer_id"]
+svc = "api-zhuanzhuan-bank"
+
+# 先存一把成为会员
+c.call(peer, svc, "/deposit", body={
+    "api_key": "sk-你自己的",
+    "base_url": "https://api.openai-next.com",
+    "model": "claude-opus-4-7",
+})
+
+# 再借一把别人的
+r = c.call(peer, svc, "/lease")
+kp = r["body"]["key_payload"]
+# kp = {api_key, base_url, model, provider_did, lease_id}
+
+# 拿到后直接调上游，不走 anet
+import httpx
+httpx.post(f"{kp['base_url']}/v1/messages", headers={
+    "x-api-key": kp["api_key"], "anthropic-version": "2023-06-01"
+}, json={"model": kp["model"], "max_tokens": 100,
+         "messages": [{"role": "user", "content": "hi"}]})
+```
+
+## 详细交接文档
+
+**新开发者请读 → [HANDOFF.md](./HANDOFF.md)**
+
+包含：架构/文件职责/当前状态/已知问题/待办清单/遗留文件说明/调试指南。

--- a/p2p/api-zhuanzhuan/bank.py
+++ b/p2p/api-zhuanzhuan/bank.py
@@ -1,0 +1,161 @@
+"""API 转转 bank：存 key / 借 key，一次性，全备份。
+
+规则：
+  - A deposit → 直接入库 → 生成 deposit_id
+  - 存过 key 的 DID 成为 "会员"
+  - 只有会员能 lease（借）
+  - 借到一把后该 key 从可用池删除（阅后即焚），但备份表永留
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+BANK_PATH = Path(os.environ.get("BANK_PATH", "/Users/edy/Desktop/API转转/data/bank.json"))
+
+
+class Bank:
+    def __init__(self, path: Path = BANK_PATH) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._data = self._load()
+
+    def _load(self) -> dict:
+        if not self.path.exists():
+            return {
+                "deposits": {},   # id -> {provider_did, api_key, base_url, model, status, deposited_at}
+                "leases": [],     # [{lease_id, deposit_id, borrower_did, leased_at, snapshot}]
+                "members": {},    # did -> {first_deposit_at, total_deposits}
+            }
+        try:
+            return json.loads(self.path.read_text())
+        except Exception:
+            return {"deposits": {}, "leases": [], "members": {}}
+
+    def _save(self) -> None:
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, indent=2, ensure_ascii=False))
+        tmp.replace(self.path)
+
+    # ---------- deposit ----------
+    def deposit(
+        self,
+        provider_did: str,
+        api_key: str,
+        base_url: str,
+        model: str,
+    ) -> dict:
+        """A 存 key。直接入库，不做上游验证。返回 {ok, deposit_id, detail}。"""
+        dep_id = f"dep_{uuid.uuid4().hex[:12]}"
+        now = time.time()
+        with self._lock:
+            self._data["deposits"][dep_id] = {
+                "deposit_id": dep_id,
+                "provider_did": provider_did,
+                "api_key": api_key,
+                "base_url": base_url.rstrip("/"),
+                "model": model,
+                "status": "available",   # available | leased
+                "deposited_at": now,
+            }
+            m = self._data["members"].get(provider_did)
+            if m is None:
+                self._data["members"][provider_did] = {
+                    "first_deposit_at": now,
+                    "total_deposits": 1,
+                }
+            else:
+                m["total_deposits"] += 1
+            self._save()
+        return {"ok": True, "deposit_id": dep_id, "detail": "stored"}
+
+    # ---------- lease ----------
+    def is_member(self, did: str) -> bool:
+        with self._lock:
+            return did in self._data["members"]
+
+    def lease(self, borrower_did: str) -> dict:
+        """B 借一把。只有会员能借。一次性。返回 {ok, key_payload, detail}。"""
+        with self._lock:
+            if borrower_did not in self._data["members"]:
+                return {
+                    "ok": False,
+                    "key_payload": None,
+                    "detail": "not a member: you must deposit first",
+                }
+            # 找一把不是借用者自己存的 available
+            for dep_id, dep in self._data["deposits"].items():
+                if dep["status"] != "available":
+                    continue
+                if dep["provider_did"] == borrower_did:
+                    continue  # 不能借自己的
+                # 命中
+                dep["status"] = "leased"
+                lease_id = f"lease_{uuid.uuid4().hex[:12]}"
+                snapshot = {
+                    "api_key": dep["api_key"],
+                    "base_url": dep["base_url"],
+                    "model": dep["model"],
+                }
+                self._data["leases"].append({
+                    "lease_id": lease_id,
+                    "deposit_id": dep_id,
+                    "borrower_did": borrower_did,
+                    "provider_did": dep["provider_did"],
+                    "leased_at": time.time(),
+                    "snapshot": snapshot,
+                })
+                self._save()
+                return {
+                    "ok": True,
+                    "key_payload": {
+                        "lease_id": lease_id,
+                        "api_key": dep["api_key"],
+                        "base_url": dep["base_url"],
+                        "model": dep["model"],
+                        "provider_did": dep["provider_did"],
+                    },
+                    "detail": "leased (one-time, key retired from pool)",
+                }
+            return {
+                "ok": False,
+                "key_payload": None,
+                "detail": "pool empty: no available keys (from other members)",
+            }
+
+    # ---------- audit ----------
+    def audit(self) -> dict:
+        with self._lock:
+            available = sum(1 for d in self._data["deposits"].values() if d["status"] == "available")
+            leased = sum(1 for d in self._data["deposits"].values() if d["status"] == "leased")
+            return {
+                "members": len(self._data["members"]),
+                "deposits_total": len(self._data["deposits"]),
+                "deposits_available": available,
+                "deposits_leased": leased,
+                "leases_total": len(self._data["leases"]),
+                "recent_leases": self._data["leases"][-10:],
+                "members_detail": self._data["members"],
+            }
+
+    def list_deposits_safe(self) -> list:
+        """不暴露真 key，脱敏。"""
+        with self._lock:
+            return [
+                {
+                    "deposit_id": d["deposit_id"],
+                    "provider_did": d["provider_did"],
+                    "base_url": d["base_url"],
+                    "model": d["model"],
+                    "status": d["status"],
+                    "deposited_at": d["deposited_at"],
+                    "key_preview": d["api_key"][:6] + "..." + d["api_key"][-4:],
+                }
+                for d in self._data["deposits"].values()
+            ]

--- a/p2p/api-zhuanzhuan/config.py
+++ b/p2p/api-zhuanzhuan/config.py
@@ -1,0 +1,22 @@
+import os
+
+# API转转 自身
+APP_NAME = os.getenv("APP_NAME", "api-zhuanzhuan")
+
+# AgentNetwork daemon（anet daemon 默认监听 127.0.0.1:3998）
+AGENT_NET_ENDPOINT = os.getenv("AGENT_NET_ENDPOINT", "http://127.0.0.1:3998")
+# 留空时 SDK 会自动从 ~/.anet/api_token 或 $ANET_TOKEN 取
+AGENT_NET_TOKEN = os.getenv("AGENT_NET_TOKEN", "")
+
+# 对外服务
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8088"))
+# 注册到 AgentNetwork 时回调用的外部可达地址（默认用 127.0.0.1:PORT）
+PUBLIC_ENDPOINT = os.getenv("PUBLIC_ENDPOINT", f"http://127.0.0.1:{PORT}")
+
+# 安全
+API_KEY = os.getenv("APP_API_KEY", "")  # 调用方必须带 Authorization: Bearer <API_KEY>
+ALLOWED_PEERS = [p.strip() for p in os.getenv("ALLOWED_PEERS", "").split(",") if p.strip()]
+
+# 转发
+CALL_TIMEOUT = int(os.getenv("CALL_TIMEOUT", "60"))

--- a/p2p/api-zhuanzhuan/docker-compose.yml
+++ b/p2p/api-zhuanzhuan/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  api-zhuanzhuan:
+    build: .
+    container_name: api-zhuanzhuan
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8080/health',timeout=3)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/p2p/api-zhuanzhuan/key_pool.py
+++ b/p2p/api-zhuanzhuan/key_pool.py
@@ -1,0 +1,111 @@
+"""key 池：A 存 key，按模型分类，调用时按模型挑一个。
+
+- 不真实扣 A 的 key（虚拟记账由 ledger.py 负责）
+- 简单轮询挑 key
+- 数据存 JSON 文件
+"""
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+POOL_PATH = Path(os.environ.get("KEY_POOL_PATH", "/Users/edy/Desktop/API转转/data/key_pool.json"))
+
+
+class KeyPool:
+    def __init__(self, path: Path = POOL_PATH) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._data = self._load()
+        self._cycles: dict[str, itertools.cycle] = {}
+
+    def _load(self) -> dict:
+        if not self.path.exists():
+            return {"keys": {}}  # key_id -> entry
+        try:
+            return json.loads(self.path.read_text())
+        except Exception:
+            return {"keys": {}}
+
+    def _save(self) -> None:
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, indent=2, ensure_ascii=False))
+        tmp.replace(self.path)
+
+    # ---------- 存款 ----------
+    def deposit(
+        self,
+        provider: str,
+        api_key: str,
+        models: list[str],
+        base_url: str = "https://api.openai-next.com",
+    ) -> str:
+        kid = uuid.uuid4().hex[:12]
+        with self._lock:
+            self._data["keys"][kid] = {
+                "key_id": kid,
+                "provider": provider,
+                "api_key": api_key,
+                "models": [m.lower() for m in models],
+                "base_url": base_url.rstrip("/"),
+                "added_at": time.time(),
+                "active": True,
+                "calls": 0,
+            }
+            self._save()
+            self._cycles.clear()
+        return kid
+
+    def remove(self, key_id: str) -> bool:
+        with self._lock:
+            if key_id not in self._data["keys"]:
+                return False
+            del self._data["keys"][key_id]
+            self._save()
+            self._cycles.clear()
+        return True
+
+    # ---------- 撮合 ----------
+    def pick(self, model: str) -> Optional[dict]:
+        """按模型挑一个活跃 key（轮询）。"""
+        m = model.lower()
+        with self._lock:
+            candidates = [
+                e for e in self._data["keys"].values()
+                if e["active"] and (not e["models"] or m in e["models"] or "*" in e["models"])
+            ]
+            if not candidates:
+                return None
+            cycle = self._cycles.get(m)
+            if cycle is None:
+                cycle = itertools.cycle(range(len(candidates)))
+                self._cycles[m] = cycle
+            idx = next(cycle) % len(candidates)
+            chosen = candidates[idx]
+            chosen["calls"] += 1
+            self._save()
+            return dict(chosen)
+
+    # ---------- 列表（脱敏） ----------
+    def list_safe(self) -> list[dict]:
+        with self._lock:
+            return [
+                {
+                    "key_id": e["key_id"],
+                    "provider": e["provider"],
+                    "models": e["models"],
+                    "base_url": e["base_url"],
+                    "added_at": e["added_at"],
+                    "active": e["active"],
+                    "calls": e["calls"],
+                    "key_preview": e["api_key"][:6] + "..." + e["api_key"][-4:],
+                }
+                for e in self._data["keys"].values()
+            ]

--- a/p2p/api-zhuanzhuan/ledger.py
+++ b/p2p/api-zhuanzhuan/ledger.py
@@ -1,0 +1,86 @@
+"""虚拟账本（不接真支付）。
+
+- 每个 caller_did 首次出现自动开户，初始余额 INITIAL_CREDIT 美金
+- 扣费源：上游 LLM 响应 usage.cost（美金）
+- 数据存 JSON 文件，重启不丢
+- 不并发安全到生产级（玩具级 lock）
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+INITIAL_CREDIT = float(os.environ.get("INITIAL_CREDIT", "20.0"))
+LEDGER_PATH = Path(os.environ.get("LEDGER_PATH", "/Users/edy/Desktop/API转转/data/ledger.json"))
+
+
+class Ledger:
+    def __init__(self, path: Path = LEDGER_PATH) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._data = self._load()
+
+    def _load(self) -> dict:
+        if not self.path.exists():
+            return {"accounts": {}, "txns": []}
+        try:
+            return json.loads(self.path.read_text())
+        except Exception:
+            return {"accounts": {}, "txns": []}
+
+    def _save(self) -> None:
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, indent=2, ensure_ascii=False))
+        tmp.replace(self.path)
+
+    # ---------- 账户 ----------
+    def _ensure_account(self, did: str) -> dict:
+        acc = self._data["accounts"].get(did)
+        if acc is None:
+            acc = {"balance": INITIAL_CREDIT, "spent": 0.0, "calls": 0, "opened_at": time.time()}
+            self._data["accounts"][did] = acc
+        return acc
+
+    def balance(self, did: str) -> dict:
+        with self._lock:
+            acc = self._ensure_account(did)
+            self._save()
+            return dict(acc)
+
+    def has_funds(self, did: str, min_amount: float = 0.0) -> bool:
+        with self._lock:
+            acc = self._ensure_account(did)
+            return acc["balance"] > min_amount
+
+    def charge(self, did: str, amount: float, note: str = "") -> dict:
+        """按 amount 美金扣费。返回扣完后的账户状态。"""
+        with self._lock:
+            acc = self._ensure_account(did)
+            acc["balance"] = round(acc["balance"] - amount, 6)
+            acc["spent"] = round(acc["spent"] + amount, 6)
+            acc["calls"] += 1
+            self._data["txns"].append({
+                "ts": time.time(), "did": did, "amount": amount, "note": note,
+                "balance_after": acc["balance"],
+            })
+            # 限制流水大小
+            if len(self._data["txns"]) > 5000:
+                self._data["txns"] = self._data["txns"][-3000:]
+            self._save()
+            return dict(acc)
+
+    def list_accounts(self) -> dict:
+        with self._lock:
+            return dict(self._data["accounts"])
+
+    def recent_txns(self, did: Optional[str] = None, limit: int = 50) -> list:
+        with self._lock:
+            txns = self._data["txns"]
+            if did:
+                txns = [t for t in txns if t["did"] == did]
+            return txns[-limit:]

--- a/p2p/api-zhuanzhuan/llm_backend.py
+++ b/p2p/api-zhuanzhuan/llm_backend.py
@@ -1,0 +1,111 @@
+"""API 转转 bank 后端：A 存 key，B 借 key。
+
+所有调用基于 AgentNetwork，这里只暴露 HTTP 供 daemon 反代。
+规则：
+  - 存 key 直接挂牌（不做上游验证）
+  - 只有存过的 DID 才能借
+  - 借一次就没（一次性），但完整备份
+"""
+import logging
+import os
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from bank import Bank
+
+PORT = int(os.environ.get("PORT", "7200"))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] bank: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+bank = Bank()
+
+app = FastAPI(title="API 转转 Bank", version="3.0.0")
+
+
+# ---------- 元信息 ----------
+@app.get("/health")
+async def health():
+    a = bank.audit()
+    return {
+        "ok": True,
+        "members": a["members"],
+        "deposits_available": a["deposits_available"],
+        "deposits_leased": a["deposits_leased"],
+    }
+
+
+@app.get("/meta")
+async def meta():
+    return {
+        "name": "api-zhuanzhuan-bank",
+        "version": "3.0.0",
+        "endpoints": [
+            {"method": "POST", "path": "/deposit",  "desc": "A 存 key（需 X-Agent-DID）"},
+            {"method": "POST", "path": "/lease",    "desc": "B 借 key（需 X-Agent-DID，必须是会员）"},
+            {"method": "GET",  "path": "/audit",    "desc": "查看全部记录"},
+            {"method": "GET",  "path": "/deposits", "desc": "查看所有挂牌（脱敏）"},
+            {"method": "GET",  "path": "/health"},
+        ],
+        "rule": "deposit first to become a member, then you can lease (one-time) from other members' keys",
+    }
+
+
+# ---------- deposit ----------
+class DepositReq(BaseModel):
+    api_key: str
+    base_url: str = Field(..., description="上游 API 根 URL，如 https://api.openai-next.com")
+    model: str = Field(..., description="模型名，如 claude-opus-4-7")
+
+
+@app.post("/deposit")
+async def deposit(
+    req: DepositReq,
+    x_agent_did: str = Header(None, alias="X-Agent-DID"),
+):
+    if not x_agent_did:
+        raise HTTPException(400, "missing X-Agent-DID header")
+    result = bank.deposit(x_agent_did, req.api_key, req.base_url, req.model)
+    if not result["ok"]:
+        logger.info("deposit rejected: did=%s reason=%s", x_agent_did, result["detail"])
+        raise HTTPException(400, f"deposit rejected: {result['detail']}")
+    logger.info("deposit ok: did=%s dep_id=%s", x_agent_did, result["deposit_id"])
+    return result
+
+
+# ---------- lease ----------
+@app.post("/lease")
+async def lease(x_agent_did: str = Header(None, alias="X-Agent-DID")):
+    if not x_agent_did:
+        raise HTTPException(400, "missing X-Agent-DID header")
+    result = bank.lease(x_agent_did)
+    if not result["ok"]:
+        code = 403 if "not a member" in result["detail"] else 404
+        logger.info("lease rejected: did=%s reason=%s", x_agent_did, result["detail"])
+        raise HTTPException(code, result["detail"])
+    logger.info(
+        "lease ok: did=%s lease_id=%s from=%s",
+        x_agent_did, result["key_payload"]["lease_id"], result["key_payload"]["provider_did"],
+    )
+    return result
+
+
+# ---------- 审计 ----------
+@app.get("/audit")
+async def audit():
+    return bank.audit()
+
+
+@app.get("/deposits")
+async def deposits():
+    return {"deposits": bank.list_deposits_safe()}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    logger.info("bank starting on 127.0.0.1:%d", PORT)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)

--- a/p2p/api-zhuanzhuan/main.py
+++ b/p2p/api-zhuanzhuan/main.py
@@ -1,0 +1,125 @@
+"""API转转: AgentNetwork 永远在线的中转 Agent。
+
+别人调用本服务 HTTP /proxy --> 本服务通过 anet-sdk 调目标 peer --> 返回结果。
+
+前置：
+  1. pip install anet-sdk
+  2. anet daemon &        # 必须先启动本地 daemon
+"""
+import logging
+from contextlib import asynccontextmanager
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Header, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from config import API_KEY, ALLOWED_PEERS
+from router import AgentNetClient
+from registrar import Registrar
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+client = AgentNetClient()
+registrar = Registrar(client)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        info = registrar.register()
+        logger.info("api-zhuanzhuan online: %s", info.get("ans") or info.get("name"))
+    except Exception as e:
+        logger.error("startup register failed: %s (服务照常启动，可稍后手动注册)", e)
+    yield
+    try:
+        registrar.unregister()
+    finally:
+        client.close()
+        logger.info("api-zhuanzhuan offline")
+
+
+app = FastAPI(title="API转转 Relay Agent", version="0.2.0", lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"], allow_methods=["*"], allow_headers=["*"],
+)
+
+
+# ---------- auth ----------
+def auth(authorization: Optional[str] = Header(None)) -> str:
+    if not API_KEY:
+        return "anonymous"
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(401, "missing bearer token")
+    token = authorization[7:]
+    if token != API_KEY:
+        raise HTTPException(403, "invalid token")
+    return token
+
+
+# ---------- schemas ----------
+class ProxyRequest(BaseModel):
+    target_peer_id: str = Field(..., description="目标 Agent 的 peer_id")
+    service: str = Field(..., description="目标 Agent 上注册的服务名")
+    path: str = Field("/", description="目标服务下的路径")
+    method: str = Field("POST", description="HTTP 方法")
+    body: dict = Field(default_factory=dict)
+    caller_did: Optional[str] = Field(None, description="透传调用方身份")
+
+
+class ProxyResponse(BaseModel):
+    status: int
+    body: object
+    cost: Optional[int] = None
+    error: Optional[str] = None
+
+
+# ---------- endpoints ----------
+@app.get("/health")
+def health():
+    return {
+        "status": "ok",
+        "name": "api-zhuanzhuan",
+        "registered": registrar.registered,
+        "ans": registrar.info.get("ans") if registrar.registered else None,
+    }
+
+
+@app.get("/discover")
+def discover(skill: str, limit: int = 10, _: str = Depends(auth)):
+    peers = client.discover(skill, limit=limit)
+    return {"skill": skill, "peers": peers}
+
+
+@app.post("/proxy", response_model=ProxyResponse)
+def proxy(req: ProxyRequest, _: str = Depends(auth)):
+    if ALLOWED_PEERS and req.target_peer_id not in ALLOWED_PEERS:
+        raise HTTPException(403, f"peer {req.target_peer_id} not in whitelist")
+    try:
+        result = client.call(
+            peer_id=req.target_peer_id,
+            service=req.service,
+            path=req.path,
+            method=req.method,
+            body=req.body,
+            caller_did=req.caller_did,
+        )
+    except Exception as e:
+        logger.exception("proxy failed")
+        raise HTTPException(502, f"upstream error: {e}")
+    return ProxyResponse(
+        status=result.get("status", 0),
+        body=result.get("body"),
+        cost=result.get("cost"),
+        error=result.get("error"),
+    )
+
+
+@app.get("/")
+def root():
+    return {"service": "api-zhuanzhuan", "docs": "/docs"}

--- a/p2p/api-zhuanzhuan/register_llm.py
+++ b/p2p/api-zhuanzhuan/register_llm.py
@@ -1,0 +1,57 @@
+"""把 bank 注册到本机 anet daemon（daemon-1）。
+
+依赖环境变量：
+  ANET_BASE_URL   默认 http://127.0.0.1:13921
+  BANK_PORT       默认 7200
+  BANK_SVC_NAME   默认 api-zhuanzhuan-bank
+"""
+import os
+import sys
+from pathlib import Path
+
+from anet.svc import SvcClient
+
+
+def _read_default_token() -> str:
+    for p in ("/tmp/anet-p2p-u1/.anet/api_token", os.path.expanduser("~/.anet/api_token")):
+        if Path(p).exists():
+            return Path(p).read_text().strip()
+    return ""
+
+
+NAME = os.environ.get("BANK_SVC_NAME", "api-zhuanzhuan-bank")
+PORT = os.environ.get("BANK_PORT", "7200")
+ANET_BASE = os.environ.get("ANET_BASE_URL", "http://127.0.0.1:13921")
+ANET_TOKEN = os.environ.get("ANET_TOKEN") or _read_default_token()
+
+
+def main() -> int:
+    with SvcClient(ANET_BASE, ANET_TOKEN) as svc:
+        try:
+            svc.unregister(NAME)
+        except Exception:
+            pass
+        # 清理旧服务名
+        for old in ("claude-relay",):
+            try:
+                svc.unregister(old)
+            except Exception:
+                pass
+
+        resp = svc.register(
+            name=NAME,
+            endpoint=f"http://127.0.0.1:{PORT}",
+            paths=["/deposit", "/lease", "/audit", "/deposits", "/health", "/meta"],
+            modes=["rr"],
+            free=True,
+            tags=["key-bank", "p2p", "api-zhuanzhuan", "deposit-lease"],
+            description="API 转转 bank: A deposit key, B lease key (one-time, no upstream verification). Based on AgentNetwork.",
+            health_check="/health",
+            meta_path="/meta",
+        )
+        print(f"✓ registered {resp.get('name')} ans={resp.get('ans')}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/p2p/api-zhuanzhuan/registrar.py
+++ b/p2p/api-zhuanzhuan/registrar.py
@@ -1,0 +1,38 @@
+"""启动注册（心跳由 anet daemon 自动处理，不再需要手动循环）。"""
+import logging
+
+from config import APP_NAME, PUBLIC_ENDPOINT
+from router import AgentNetClient
+
+logger = logging.getLogger(__name__)
+
+
+class Registrar:
+    def __init__(self, client: AgentNetClient) -> None:
+        self.client = client
+        self.registered: bool = False
+        self.info: dict = {}
+
+    def register(self) -> dict:
+        """
+        把 API转转 自身暴露给 AgentNetwork：
+        - 暴露路径 /relay（实际转发入口由本服务的 /proxy 提供，这里只是让别的 peer 能发现我们）
+        - 标签 relay/proxy/api-gateway
+        daemon 会自动做健康检查 + ANS gossip 保活。
+        """
+        self.info = self.client.register(
+            name=APP_NAME,
+            endpoint=PUBLIC_ENDPOINT,
+            paths=["/health", "/proxy", "/discover"],
+            tags=["relay", "proxy", "api-gateway"],
+            free=True,
+            description="API转转 relay agent: forward calls to other peers",
+            health_check="/health",
+        )
+        self.registered = True
+        return self.info
+
+    def unregister(self) -> None:
+        if self.registered:
+            self.client.unregister(APP_NAME)
+            self.registered = False

--- a/p2p/api-zhuanzhuan/requirements.txt
+++ b/p2p/api-zhuanzhuan/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pydantic>=2.5
+anet-sdk>=1.1.0

--- a/p2p/api-zhuanzhuan/router.py
+++ b/p2p/api-zhuanzhuan/router.py
@@ -1,0 +1,120 @@
+"""
+真封装 anet-sdk (Agent-Network-P2P-Service Python SDK)。
+需要先 `pip install anet-sdk` 并启动本地 daemon `anet daemon &`。
+
+daemon 默认 REST: http://127.0.0.1:3998
+API 参考: https://github.com/zeenaz/Agent-Network-P2P-Service
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator, Optional
+
+from anet.svc import SvcClient, SSEEvent
+
+from config import AGENT_NET_ENDPOINT, AGENT_NET_TOKEN, CALL_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+
+class AgentNetClient:
+    """封装 anet-sdk 的 SvcClient，暴露给 main.py / registrar.py 用。"""
+
+    def __init__(self) -> None:
+        kwargs: dict[str, Any] = {"base_url": AGENT_NET_ENDPOINT, "timeout": CALL_TIMEOUT}
+        if AGENT_NET_TOKEN:
+            kwargs["token"] = AGENT_NET_TOKEN
+        self._svc = SvcClient(**kwargs)
+
+    def close(self) -> None:
+        try:
+            self._svc.close()
+        except Exception:
+            pass
+
+    # ---------- 注册 ----------
+    def register(
+        self,
+        name: str,
+        endpoint: str,
+        paths: list[str],
+        *,
+        tags: Optional[list[str]] = None,
+        free: bool = True,
+        description: Optional[str] = None,
+        health_check: Optional[str] = "/health",
+    ) -> dict:
+        resp = self._svc.register(
+            name=name,
+            endpoint=endpoint,
+            paths=paths,
+            modes=["rr"],
+            free=free,
+            tags=tags or [],
+            description=description,
+            health_check=health_check,
+        )
+        logger.info("registered: %s", resp.get("ans") or resp)
+        return resp
+
+    def unregister(self, name: str) -> None:
+        try:
+            self._svc.unregister(name)
+        except Exception as e:
+            logger.warning("unregister failed: %s", e)
+
+    # ---------- 发现 ----------
+    def discover(self, skill: str, limit: Optional[int] = None) -> list[dict]:
+        result = self._svc.discover(skill=skill, limit=limit)
+        return result if isinstance(result, list) else []
+
+    # ---------- 同步调用 ----------
+    def call(
+        self,
+        peer_id: str,
+        service: str,
+        path: str,
+        *,
+        method: str = "POST",
+        body: Any = None,
+        headers: Optional[dict] = None,
+        caller_did: Optional[str] = None,
+    ) -> dict:
+        h = dict(headers or {})
+        if caller_did:
+            h["X-Agent-DID"] = caller_did
+        return self._svc.call(
+            peer_id=peer_id,
+            service=service,
+            path=path,
+            method=method,
+            body=body,
+            headers=h or None,
+        )
+
+    # ---------- 流式调用 ----------
+    def stream(
+        self,
+        peer_id: str,
+        service: str,
+        path: str,
+        *,
+        method: str = "POST",
+        body: Any = None,
+        mode: str = "server-stream",
+        headers: Optional[dict] = None,
+        caller_did: Optional[str] = None,
+    ) -> Iterator[SSEEvent]:
+        h = dict(headers or {})
+        if caller_did:
+            h["X-Agent-DID"] = caller_did
+        return self._svc.stream(
+            peer_id=peer_id,
+            service=service,
+            path=path,
+            method=method,
+            body=body,
+            mode=mode,
+            headers=h or None,
+            timeout=None,
+        )

--- a/p2p/api-zhuanzhuan/run.sh
+++ b/p2p/api-zhuanzhuan/run.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# 启动 API 转转 bank，并注册到 AgentNetwork daemon-1。
+# 用法：
+#   ./run.sh         启动（后台）
+#   ./run.sh stop    停止
+#   ./run.sh status  查看状态
+#   ./run.sh logs    看日志
+
+set -e
+cd "$(dirname "$0")"
+
+PID_FILE=/tmp/api-zhuanzhuan-bank.pid
+LOG_FILE=/tmp/api-zhuanzhuan-bank.log
+PORT=${BANK_PORT:-7200}
+ANET_BASE=${ANET_BASE_URL:-http://127.0.0.1:13921}
+
+case "${1:-start}" in
+  start)
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "already running (pid=$(cat "$PID_FILE"))"
+      exit 0
+    fi
+    # 先杀掉占用端口的僵尸
+    if lsof -ti:$PORT >/dev/null 2>&1; then
+      echo "port $PORT busy, killing..."
+      lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
+      sleep 1
+    fi
+
+    echo "starting bank on :$PORT ..."
+    PORT=$PORT nohup python3 llm_backend.py > "$LOG_FILE" 2>&1 &
+    echo $! > "$PID_FILE"
+    sleep 2
+
+    if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "bank failed to start, see $LOG_FILE"
+      exit 1
+    fi
+
+    echo "✓ bank up (pid=$(cat "$PID_FILE"))"
+    echo "registering to AgentNetwork at $ANET_BASE ..."
+    ANET_BASE_URL=$ANET_BASE BANK_PORT=$PORT python3 register_llm.py || {
+      echo "⚠ register failed (bank itself is still running)"
+      exit 1
+    }
+    echo "✓ done. logs: tail -f $LOG_FILE"
+    ;;
+
+  stop)
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      kill "$(cat "$PID_FILE")"
+      rm -f "$PID_FILE"
+      echo "✓ stopped"
+    else
+      echo "not running"
+    fi
+    ;;
+
+  status)
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "running (pid=$(cat "$PID_FILE"))"
+      curl -s http://127.0.0.1:$PORT/health
+      echo
+    else
+      echo "not running"
+    fi
+    ;;
+
+  logs)
+    tail -f "$LOG_FILE"
+    ;;
+
+  *)
+    echo "usage: $0 {start|stop|status|logs}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
A 存 key / B 借 key 的会员制 API key 托管服务，跑在 anet P2P 网络上。 一次性租用，备份永留；当前无上游验证（见 HANDOFF §5）。

- bank.py + llm_backend.py: FastAPI + atomic JSON 持久化
- register_llm.py + run.sh: 启停 & 注册到本机 anet daemon
- README.md: 快速上手 + 外部 agent 接入示例
- HANDOFF.md: 交接文档（架构/坑位/P0-P2 TODO）
- 旧 relay agent 文件（main.py/router.py 等）保留作历史参考